### PR TITLE
Don't import org.ice4j.socket.jdk8 (fix compilation)

### DIFF
--- a/src/main/java/org/jitsi/rest/MuxServerConnector.java
+++ b/src/main/java/org/jitsi/rest/MuxServerConnector.java
@@ -23,7 +23,6 @@ import java.util.*;
 
 import org.eclipse.jetty.server.*;
 import org.ice4j.socket.*;
-import org.ice4j.socket.jdk8.*;
 
 /**
  * Implements a Jetty {@code ServerConnector} which is capable of sharing its


### PR DESCRIPTION
ice4j pom file excludes ```**/jdk8/**``` from compilation, so this import fails

Signed-off-by: Etienne CHAMPETIER <champetier.etienne@gmail.com>