### PR TITLE
Moves VersionService implementation from the JVB.

### DIFF
--- a/src/main/java/org/jitsi/version/AbstractVersionActivator.java
+++ b/src/main/java/org/jitsi/version/AbstractVersionActivator.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.version;
+
+import net.java.sip.communicator.util.*;
+
+import org.jitsi.service.configuration.*;
+import org.jitsi.service.version.Version;
+import org.jitsi.service.version.*;
+
+import org.osgi.framework.*;
+
+import java.util.regex.*;
+
+/**
+ * <p>
+ * The entry point to the {@code VersionService} implementation. We register the
+ * {@code VersionServiceImpl} instance on the OSGi bus.
+ * </p>
+ * <p>
+ * This abstract <tt>BundleActivator</tt> will provide implementation of
+ * the <tt>VersionService</tt> once {@link #getCurrentVersion()} method is
+ * provided.
+ * </p>
+ *
+ * @author George Politis
+ * @author Pawel Domas
+ */
+public abstract class AbstractVersionActivator
+    implements BundleActivator
+{
+    /**
+     * The <tt>Logger</tt> used by this <tt>VersionActivator</tt> instance for
+     * logging output.
+     */
+    private final Logger logger
+        = Logger.getLogger(AbstractVersionActivator.class);
+
+    /**
+     * The pattern that will parse strings to version object.
+     */
+    private static final Pattern PARSE_VERSION_STRING_PATTERN
+        = Pattern.compile("(\\d+)\\.(\\d+)\\.([\\d\\.]+)");
+
+    /**
+     * The OSGi <tt>BundleContext</tt>.
+     */
+    private static BundleContext bundleContext;
+
+    /**
+     * <tt>VersionImpl</tt> instance which stores the current version of the
+     * application.
+     */
+    private VersionImpl currentVersion;
+
+    /**
+     * Implementing class must return a valid {@link CurrentVersion} object.
+     *
+     * @return {@link CurrentVersion} instance which provides the details about
+     * current version of the application.
+     */
+    abstract protected CurrentVersion getCurrentVersion();
+
+    /**
+     * Called when this bundle is started so the Framework can perform the
+     * bundle-specific activities necessary to start this bundle.
+     *
+     * @param context The execution context of the bundle being started.
+     * @throws Exception If this method throws an exception, this bundle is
+     * marked as stopped and the Framework will remove this bundle's listeners,
+     * unregister all services registered by this bundle, and release all
+     * services used by this bundle.
+     */
+    public void start(BundleContext context) throws Exception
+    {
+        if (logger.isDebugEnabled())
+            logger.debug("Started.");
+
+        AbstractVersionActivator.bundleContext = context;
+
+        CurrentVersion currentVersion = getCurrentVersion();
+
+        this.currentVersion = new VersionImpl(
+                currentVersion.getDefaultAppName(),
+                currentVersion.getMajorVersion(),
+                currentVersion.getMinorVersion(),
+                currentVersion.getNightlyBuildID(),
+                currentVersion.getPreReleaseID());
+
+        VersionServiceImpl versionServiceImpl = new VersionServiceImpl();
+
+        context.registerService(
+                VersionService.class.getName(),
+                versionServiceImpl,
+                null);
+
+        String applicationName = this.currentVersion.getApplicationName();
+        String versionString = this.currentVersion.toString();
+
+        logger.debug(
+                this.currentVersion.getApplicationName()
+                    + " Version Service ... [REGISTERED]");
+
+        if (logger.isInfoEnabled())
+        {
+            logger.info(
+                    applicationName + " Version: " + applicationName + " "
+                        + versionString);
+        }
+
+        //register properties for those that would like to use them
+        ConfigurationService cfg = getConfigurationService();
+
+        cfg.setProperty(Version.PNAME_APPLICATION_NAME, applicationName, true);
+        cfg.setProperty(Version.PNAME_APPLICATION_VERSION, versionString, true);
+    }
+
+    /**
+     * Gets a <tt>ConfigurationService</tt> implementation currently registered
+     * in the <tt>BundleContext</tt> in which this bundle has been started or
+     * <tt>null</tt> if no such implementation was found.
+     *
+     * @return a <tt>ConfigurationService</tt> implementation currently
+     * registered in the <tt>BundleContext</tt> in which this bundle has been
+     * started or <tt>null</tt> if no such implementation was found
+     */
+    private static ConfigurationService getConfigurationService()
+    {
+        return
+            ServiceUtils.getService(bundleContext, ConfigurationService.class);
+    }
+
+    /**
+     * Gets the <tt>BundleContext</tt> instance within which this bundle has
+     * been started.
+     *
+     * @return the <tt>BundleContext</tt> instance within which this bundle has
+     * been started
+     */
+    public static BundleContext getBundleContext()
+    {
+        return bundleContext;
+    }
+
+    /**
+     * Called when this bundle is stopped so the Framework can perform the
+     * bundle-specific activities necessary to stop the bundle.
+     *
+     * @param context The execution context of the bundle being stopped.
+     * @throws Exception If this method throws an exception, the bundle is still
+     * marked as stopped, and the Framework will remove the bundle's listeners,
+     * unregister all services registered by the bundle, and release all
+     * services used by the bundle.
+     */
+    public void stop(BundleContext context) throws Exception
+    {
+    }
+
+    /**
+     * Implementation of the {@link VersionService}.
+     */
+    class VersionServiceImpl
+        implements VersionService
+    {
+        /**
+         * Returns a Version instance corresponding to the <tt>version</tt>
+         * string.
+         *
+         * @param version a version String that we have obtained by calling a
+         * <tt>Version.toString()</tt> method.
+         *
+         * @return the <tt>Version</tt> object corresponding to the
+         * <tt>version</tt> string. Or null if we cannot parse the string.
+         */
+        public Version parseVersionString(String version)
+        {
+            Matcher matcher = PARSE_VERSION_STRING_PATTERN.matcher(version);
+
+            if(matcher.matches() && matcher.groupCount() == 3)
+            {
+                return new VersionImpl(
+                    currentVersion.getApplicationName(),
+                    Integer.parseInt(matcher.group(1)),
+                    Integer.parseInt(matcher.group(2)),
+                    matcher.group(3),
+                    currentVersion.getPreReleaseID());
+            }
+
+            return null;
+        }
+
+        /**
+         * Returns a <tt>Version</tt> object containing version details of the
+         * the application version that we're currently running.
+         *
+         * @return a <tt>Version</tt> object containing version details of the
+         * application version that we're currently running.
+         */
+        public Version getCurrentVersion()
+        {
+            return currentVersion;
+        }
+    }
+}

--- a/src/main/java/org/jitsi/version/CurrentVersion.java
+++ b/src/main/java/org/jitsi/version/CurrentVersion.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.version;
+
+/**
+ * The interface provides the details about the current version of
+ * the application.
+ *
+ * @author Pawel Domas
+ */
+public interface CurrentVersion
+{
+    /**
+     * Method must return default name of the application.
+     *
+     * @return a <tt>String</tt> which is the default value for the application
+     * name.
+     */
+    String getDefaultAppName();
+
+    /**
+     * Returns the version major of the current application version. In an
+     * example 2.3.1 version string 2 is the version major. The version major
+     * number changes when a relatively extensive set of new features and
+     * possibly rearchitecturing have been applied to the application.
+     *
+     * @return the version major String.
+     */
+    int getMajorVersion();
+
+    /**
+     * Returns the version minor of the current application version. In an
+     * example 2.3.1 version string 3 is the version minor. The version minor
+     * number changes after adding enhancements and possibly new features to a
+     * given application version.
+     *
+     * @return the version minor integer.
+     */
+    int getMinorVersion();
+
+    /**
+     * If this is a nightly build, returns the build identifies (e.g.
+     * nightly-2007.12.07-06.45.17). If this is not a nightly build version,
+     * the method returns <tt>null</tt>.
+     *
+     * @return a String containing a nightly build identifier or <tt>null</tt>
+     * if this is a release version and therefore not a nightly build.
+     */
+    String getNightlyBuildID();
+
+    /**
+     * Returns the version pre-release ID of the current application version
+     * and <tt>null</tt> if this version is not a pre-release. Version
+     * pre-release id-s exist only for pre-release versions and are
+     * <tt>null<tt/> otherwise.
+     *
+     * @return a String containing the version pre-release ID.
+     */
+    String getPreReleaseID();
+}

--- a/src/main/java/org/jitsi/version/VersionImpl.java
+++ b/src/main/java/org/jitsi/version/VersionImpl.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.version;
+
+import net.java.sip.communicator.util.*;
+
+import org.jitsi.service.resources.*;
+import org.jitsi.service.version.*;
+import org.jitsi.service.version.util.*;
+import org.jitsi.util.*;
+
+/**
+ * Implements {@link Version} interface by providing the pieces missing from
+ * {@link AbstractVersion}.
+ *
+ * @author Pawel Domas
+ */
+class VersionImpl
+    extends AbstractVersion
+{
+    /**
+     * The application name.
+     */
+    private String applicationName;
+
+    /**
+     * The default application name which will be used in case we fail to obtain
+     * one in {@link #getApplicationName()}.
+     */
+    private final String defaultApplicationName;
+
+    /**
+     * The nightly build ID.
+     */
+    private final String nightlyBuildId;
+
+    /**
+     * Pre-release ID holder.
+     */
+    private final String preReleaseId;
+
+    /**
+     * Creates version object with custom major, minor and nightly build id.
+     *
+     * @param defaultApplicationName default application name which will be used
+     * if we fail to obtain one from the <tt>ResourceManagementService</tt>.
+     * @param majorVersion the major version to use.
+     * @param minorVersion the minor version to use.
+     * @param nightlyBuildID the nightly build id value for new version object.
+     */
+    VersionImpl(String defaultApplicationName,
+                int majorVersion,
+                int minorVersion,
+                String nightlyBuildID,
+                String preReleaseId)
+    {
+        super(majorVersion, minorVersion, nightlyBuildID);
+
+        this.defaultApplicationName = defaultApplicationName;
+        this.nightlyBuildId = nightlyBuildID;
+        this.preReleaseId = preReleaseId;
+    }
+
+    /**
+     * Indicates if this application version corresponds to a nightly
+     * build of a repository snapshot or to an official release.
+     *
+     * @return {@code true} if this is a build of a nightly repository snapshot
+     * and {@code false} if this is an official release.
+     */
+    public boolean isNightly()
+    {
+        return !StringUtils.isNullOrEmpty(nightlyBuildId);
+    }
+
+    /**
+     * Indicates whether this version represents a prerelease (i.e. an
+     * incomplete release like an alpha, beta or release candidate version).
+     *
+     * @return {@code true} if this version represents a prerelease and
+     * {@code false} otherwise.
+     */
+    public boolean isPreRelease()
+    {
+        return !StringUtils.isNullOrEmpty(preReleaseId);
+    }
+
+    /**
+     * Returns the version prerelease ID of the current application
+     * version and {@code null} if this version is not a prerelease.
+     *
+     * @return a {@code String} containing the version prerelease ID.
+     */
+    public String getPreReleaseID()
+    {
+        return isPreRelease() ? preReleaseId : null;
+    }
+
+    /**
+     * Returns the name of the application that we're currently running.
+     *
+     * @return the name of the application that we're currently running.
+     */
+    public String getApplicationName()
+    {
+        if (applicationName == null)
+        {
+            try
+            {
+                // XXX There is no need to have the ResourceManagementService
+                // instance as a static field of the VersionImpl class because
+                // it will be used once only anyway.
+                ResourceManagementService resources
+                    = ServiceUtils.getService(
+                            AbstractVersionActivator.getBundleContext(),
+                            ResourceManagementService.class);
+
+                if (resources != null)
+                {
+                    applicationName
+                        = resources.getSettingsString(
+                                "service.gui.APPLICATION_NAME");
+                }
+            }
+            catch (Exception e)
+            {
+                // If resource bundle is not found or the key is missing, return
+                // the default name.
+            }
+            finally
+            {
+                if (applicationName == null)
+                {
+                    // Allow the application name to be overridden by the user.
+                    applicationName
+                        = System.getProperty(Version.PNAME_APPLICATION_NAME);
+                    if (applicationName == null
+                        || applicationName.length() == 0)
+                    {
+                        applicationName = defaultApplicationName;
+                    }
+                }
+            }
+        }
+        return applicationName;
+    }
+}


### PR DESCRIPTION
VersionServiceImpl has been moved to Jicoco, so that it can be reused in other components. They have to provide VersionServiceActivator and CurrentVersion interface implementation. The method for injecting version remains the same(done in build.xml of the component).

See https://github.com/jitsi/jitsi-videobridge/compare/version_impl?expand=1 for usage example.