### PR TITLE
Jetty logging configuration through Logger

### DIFF
--- a/src/main/java/org/jitsi/rest/AbstractJettyBundleActivator.java
+++ b/src/main/java/org/jitsi/rest/AbstractJettyBundleActivator.java
@@ -88,6 +88,27 @@ public abstract class AbstractJettyBundleActivator
     private static final Logger logger
         = Logger.getLogger(AbstractJettyBundleActivator.class);
 
+    static
+    {
+        // Allow the logging level of Jetty to be configured through the logger
+        // of AbstractJettyBundleActivator.
+        String jettyLogLevelProperty = "org.eclipse.jetty.LEVEL";
+
+        if (System.getProperty(jettyLogLevelProperty) == null)
+        {
+            String jettyLogLevelValue;
+
+            if (logger.isDebugEnabled())
+                jettyLogLevelValue = "DEBUG";
+            else if (logger.isInfoEnabled())
+                jettyLogLevelValue = "INFO";
+            else
+                jettyLogLevelValue = null;
+            if (jettyLogLevelValue != null)
+                System.setProperty(jettyLogLevelProperty, jettyLogLevelValue);
+        }
+    }
+
     /**
      * Initializes a new {@code Handler} which handles HTTP requests by
      * delegating to a specific (consecutive) list of {@code Handler}s.


### PR DESCRIPTION
At times I need to enable debug logging in Jetty for debugging purposes. Because we utilize Logger throughout our projects, I know how to enable debug logging there without looking at documentation. However, I don't remember how to enable debug logging in Jetty without going back to its documentation. That's why I hooked up Jetty's logging configuration to Logger.