### PR TITLE
Process XMPP packets in order

### DIFF
--- a/src/main/java/org/jitsi/xmpp/component/ComponentBase.java
+++ b/src/main/java/org/jitsi/xmpp/component/ComponentBase.java
@@ -143,7 +143,7 @@ public abstract class ComponentBase
      * of the eventual issues.
      *
      * NOTE the current implementation depends on the assumption that
-     * the packets are processed by a single thread(see the first value passed
+     * the packets are processed by a single thread (see the first value passed
      * to the superclass constructor).
      */
     private long processingTimeLimit;
@@ -617,8 +617,8 @@ public abstract class ComponentBase
 
     /**
      * Utility class for measuring and logging an error if the recommended
-     * processing time limit has been exceeded(configurable with
-     * {@link #PROCESSING_TIME_LIMIT_PNAME}.
+     * processing time limit has been exceeded (configurable with
+     * {@link #PROCESSING_TIME_LIMIT_PNAME}).
      *
      * NOTE The best way for implementing this timer would be in
      * {@link AbstractComponent#processQueuedPacket(Packet)}, but the method
@@ -657,7 +657,7 @@ public abstract class ComponentBase
          * with {@link #processingStarted(IQ)} has ended. It will check if
          * the {@link #processingTimeLimit} has been exceeded and print
          * a warning message. If the current logging level is set to debug it
-         * will print the processing time for every IQ(event if the limit was
+         * will print the processing time for every IQ (event if the limit was
          * not exceeded).
          */
         private void processingEnded()

--- a/src/main/java/org/jitsi/xmpp/component/ComponentBase.java
+++ b/src/main/java/org/jitsi/xmpp/component/ComponentBase.java
@@ -40,6 +40,11 @@ public abstract class ComponentBase
     private final static Logger logger = Logger.getLogger(ComponentBase.class);
 
     /**
+     * The default value of 100 ms for {@link #processingTimeLimit}.
+     */
+    private final static long DEFAULT_PROCESSING_TIME_LIMIT = 100;
+
+    /**
      * The name of the property which configures ping interval in ms. -1 to
      * disable pings.
      */
@@ -54,6 +59,12 @@ public abstract class ComponentBase
      * The name of the property which configures {@link #pingThreshold}.
      */
     private final static String PING_THRESHOLD_PNAME = "PING_THRESHOLD";
+
+    /**
+     * The name of the property which configures {@link #processingTimeLimit}.
+     */
+    private final static String PROCESSING_TIME_LIMIT_PNAME
+        = "PROCESSING_TIME_LIMIT";
 
     /**
      * The hostname or IP address to which this component will be connected.
@@ -127,6 +138,24 @@ public abstract class ComponentBase
     private boolean started;
 
     /**
+     * The time limit for processing IQs by the component implementation which
+     * will be used to log error messages for easier detection/debugging
+     * of the eventual issues.
+     *
+     * NOTE the current implementation depends on the assumption that
+     * the packets are processed by a single thread(see the first value passed
+     * to the superclass constructor).
+     */
+    private long processingTimeLimit;
+
+    /**
+     * The timer instance used to measure packet processing time.
+     *
+     * @see #processingTimeLimit
+     */
+    private final ProcessingTimer processingTimer = new ProcessingTimer();
+
+    /**
      * Default constructor for <tt>ComponentBase</tt>.
      * @param host the hostname or IP address to which this component will be
      *             connected.
@@ -174,6 +203,10 @@ public abstract class ComponentBase
 
         pingThreshold = config.getInt(
             configPropertiesBase + PING_THRESHOLD_PNAME, 3);
+
+        processingTimeLimit = config.getLong(
+            configPropertiesBase + PROCESSING_TIME_LIMIT_PNAME,
+            DEFAULT_PROCESSING_TIME_LIMIT);
 
         logger.info("Component " + configPropertiesBase  + " config: ");
         logger.info("  ping interval: " + pingInterval + " ms");
@@ -273,10 +306,134 @@ public abstract class ComponentBase
         }
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * Should *NEVER* be called by the subclass directly.
+     *
+     * The method is final in order to enforce measurement of the IQ processing
+     * time. Subclasses should implement the processing in
+     * {@link #handleIQGetImpl(IQ)}. The semantics of that method remain
+     * the same as of {@link AbstractComponent#handleIQGet(IQ)}.
+     */
     @Override
-    protected void handleIQResult(IQ iq)
+    final protected IQ handleIQGet(IQ iq)
+        throws Exception
+    {
+        processingTimer.processingStarted(iq);
+        try
+        {
+            return handleIQGetImpl(iq);
+        }
+        finally
+        {
+            processingTimer.processingEnded();
+        }
+    }
+
+    /**
+     * Handles an <tt>IQ</tt> stanza of type <tt>get</tt>.
+     *
+     * @param iq the <tt>IQ</tt> stanza of type <tt>get</tt> which represents
+     * the request to handle.
+     *
+     * @return an <tt>IQ</tt> stanza which represents the response to
+     * the specified request or <tt>null</tt> to reply with
+     * <tt>feature-not-implemented</tt>.
+     *
+     * @throws Exception to reply with <tt>internal-server-error</tt> to the
+     * specified request.
+     *
+     * @see AbstractComponent#handleIQGet(IQ)
+     */
+    protected IQ handleIQGetImpl(IQ iq) throws Exception
+    {
+        return super.handleIQGet(iq);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Should *NEVER* be called by the subclass directly.
+     *
+     * The method is final in order to enforce measurement of the IQ processing
+     * time. Subclasses should implement the processing in
+     * {@link #handleIQSetImpl(IQ)}. The semantics of that method remain
+     * the same as of {@link AbstractComponent#handleIQSet(IQ)}.
+     */
+    @Override
+    final protected IQ handleIQSet(IQ iq)
+        throws Exception
+    {
+        processingTimer.processingStarted(iq);
+        try
+        {
+            return handleIQSetImpl(iq);
+        }
+        finally
+        {
+            processingTimer.processingEnded();
+        }
+    }
+
+    /**
+     * Handles an <tt>IQ</tt> stanza of type <tt>set</tt>.
+     *
+     * @param iq the <tt>IQ</tt> stanza of type <tt>set</tt> which represents
+     * the request to handle.
+     *
+     * @return an <tt>IQ</tt> stanza which represents the response to
+     * the specified request or <tt>null</tt> to reply with
+     * <tt>feature-not-implemented</tt>.
+     *
+     * @throws Exception to reply with <tt>internal-server-error</tt> to the
+     * specified request.
+     *
+     * @see AbstractComponent#handleIQSet(IQ)
+     */
+    protected IQ handleIQSetImpl(IQ iq) throws Exception
+    {
+        return super.handleIQSet(iq);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     *  Should *NEVER* be called by the subclass directly.
+     *
+     * The method is final in order to enforce measurement of the IQ processing
+     * time. Subclasses should implement the processing in
+     * {@link #handleIQResultImpl(IQ)}. The semantics of that method remain
+     * the same as of {@link AbstractComponent#handleIQResult(IQ)}.
+     */
+    @Override
+    final protected void handleIQResult(IQ iq)
+    {
+        try
+        {
+            processingTimer.processingStarted(iq);
+
+            handleIQResultImpl(iq);
+        }
+        finally
+        {
+            processingTimer.processingEnded();
+        }
+    }
+
+    /**
+     * Handles an <tt>IQ</tt> stanza of type <tt>result</tt>.
+     *
+     * @param iq the <tt>IQ</tt> stanza of type <tt>result</tt> which represents
+     * the response to one of the IQs previously sent by this component
+     * instance.
+     *
+     * @see AbstractComponent#handleIQResult(IQ)
+     */
+    protected void handleIQResultImpl(IQ iq)
     {
         super.handleIQResult(iq);
+
         synchronized (timeouts)
         {
             String packetId = iq.getID();
@@ -289,6 +446,44 @@ public abstract class ComponentBase
                 pingFailures = 0;
             }
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Should *NEVER* be called by the subclass directly.
+     *
+     * The method is final in order to enforce measurement of the IQ processing
+     * time. Subclasses should implement the processing in
+     * {@link #handleIQErrorImpl(IQ)}. The semantics of that method remain
+     * the same as of {@link AbstractComponent#handleIQError(IQ)}.
+     */
+    @Override
+    final protected void handleIQError(IQ iq)
+    {
+        processingTimer.processingStarted(iq);
+        try
+        {
+            handleIQErrorImpl(iq);
+        }
+        finally
+        {
+            processingTimer.processingEnded();
+        }
+    }
+
+    /**
+     * Handles an <tt>IQ</tt> stanza of type <tt>error</tt>.
+     *
+     * @param iq the <tt>IQ</tt> stanza of type <tt>error</tt> which represents
+     * an error response to one of the IQs previously sent by this component
+     * instance.
+     *
+     * @see AbstractComponent#handleIQError(IQ)
+     */
+    protected void handleIQErrorImpl(IQ iq)
+    {
+        super.handleIQError(iq);
     }
 
     /**
@@ -417,6 +612,78 @@ public abstract class ComponentBase
                     timeouts.remove(packetId);
                 }
             }
+        }
+    }
+
+    /**
+     * Utility class for measuring and logging an error if the recommended
+     * processing time limit has been exceeded(configurable with
+     * {@link #PROCESSING_TIME_LIMIT_PNAME}.
+     *
+     * NOTE The best way for implementing this timer would be in
+     * {@link AbstractComponent#processQueuedPacket(Packet)}, but the method
+     * is final.
+     *
+     * @author Pawel Domas
+     */
+    private class ProcessingTimer
+    {
+        /**
+         * The IQ for which the processing time will be measured.
+         */
+        private IQ iq;
+
+        /**
+         * Stores the timestamp on when the processing has started.
+         */
+        private long startTime;
+
+        /**
+         * Informs this timer instance that the processing for given <tt>iq</tt>
+         * has just started.
+         *
+         * @param iq the <tt>IQ</tt> for which the processing has just started.
+         */
+        private void processingStarted(IQ iq)
+        {
+            Objects.requireNonNull(iq, "iq");
+
+            this.startTime = System.currentTimeMillis();
+            this.iq = iq;
+        }
+
+        /**
+         * Method must be called when the processing of the IQ registered
+         * with {@link #processingStarted(IQ)} has ended. It will check if
+         * the {@link #processingTimeLimit} has been exceeded and print
+         * a warning message. If the current logging level is set to debug it
+         * will print the processing time for every IQ(event if the limit was
+         * not exceeded).
+         */
+        private void processingEnded()
+        {
+            // processingStarted was not called ?
+            if (iq == null)
+            {
+                return;
+            }
+
+            long processingTime = System.currentTimeMillis() - startTime;
+            if (processingTime > processingTimeLimit)
+            {
+                logger.warn(
+                        "PROCESSING TIME LIMIT EXCEEDED - it took "
+                            + processingTime + "ms to process: " + iq.toXML());
+            }
+            else if (logger.isDebugEnabled())
+            {
+                logger.debug(
+                        "It took " + processingTime  + "ms to process packet: "
+                            + iq.getID());
+            }
+
+            // XXX set to null to require the processingStarted to be called
+            iq = null;
         }
     }
 }

--- a/src/main/java/org/jitsi/xmpp/component/ComponentBase.java
+++ b/src/main/java/org/jitsi/xmpp/component/ComponentBase.java
@@ -144,6 +144,8 @@ public abstract class ComponentBase
                          String     subDomain,
                          String        secret)
     {
+        super(1 /* executor pool size */, 1000 /* packet queue size */, true);
+
         this.hostname = host;
         this.port = port;
         this.domain = domain;

--- a/src/main/java/org/jitsi/xmpp/component/ComponentBase.java
+++ b/src/main/java/org/jitsi/xmpp/component/ComponentBase.java
@@ -546,7 +546,8 @@ public abstract class ComponentBase
 
                     String domain = getDomain();
                     String subdomain = getSubdomain();
-                    KeepAliveEvent ping = new KeepAliveEvent(subdomain + "." + domain, domain);
+                    KeepAliveEvent ping
+                        = new KeepAliveEvent(subdomain + "." + domain, domain);
 
                     IQ pingIq = IQUtils.convert(ping);
 

--- a/src/main/java/org/jitsi/xmpp/component/ComponentBase.java
+++ b/src/main/java/org/jitsi/xmpp/component/ComponentBase.java
@@ -320,9 +320,10 @@ public abstract class ComponentBase
     final protected IQ handleIQGet(IQ iq)
         throws Exception
     {
-        processingTimer.processingStarted(iq);
         try
         {
+            processingTimer.processingStarted(iq);
+
             return handleIQGetImpl(iq);
         }
         finally
@@ -365,9 +366,10 @@ public abstract class ComponentBase
     final protected IQ handleIQSet(IQ iq)
         throws Exception
     {
-        processingTimer.processingStarted(iq);
         try
         {
+            processingTimer.processingStarted(iq);
+
             return handleIQSetImpl(iq);
         }
         finally
@@ -461,9 +463,10 @@ public abstract class ComponentBase
     @Override
     final protected void handleIQError(IQ iq)
     {
-        processingTimer.processingStarted(iq);
         try
         {
+            processingTimer.processingStarted(iq);
+
             handleIQErrorImpl(iq);
         }
         finally

--- a/src/main/java/org/jitsi/xmpp/component/ComponentBase.java
+++ b/src/main/java/org/jitsi/xmpp/component/ComponentBase.java
@@ -173,6 +173,11 @@ public abstract class ComponentBase
                          String     subDomain,
                          String        secret)
     {
+        // NOTE measurement of the packet processing time currently depends
+        // on the executor pool size being set to 1. If multiple packets would
+        // be processed at the same time then the threads would overwrite
+        // the values in the ProcessingTimer which means that each thread will
+        // require a separate (possibly local) instance.
         super(1 /* executor pool size */, 1000 /* packet queue size */, true);
 
         this.hostname = host;

--- a/src/main/java/org/jitsi/xmpp/component/ComponentBase.java
+++ b/src/main/java/org/jitsi/xmpp/component/ComponentBase.java
@@ -42,28 +42,28 @@ public abstract class ComponentBase
     /**
      * The default value of 100 ms for {@link #processingTimeLimit}.
      */
-    private final static long DEFAULT_PROCESSING_TIME_LIMIT = 100;
+    public final static long DEFAULT_PROCESSING_TIME_LIMIT = 100;
 
     /**
      * The name of the property which configures ping interval in ms. -1 to
      * disable pings.
      */
-    private final static String PING_INTERVAL_PNAME = "PING_INTERVAL";
+    public final static String PING_INTERVAL_PNAME = "PING_INTERVAL";
 
     /**
      * The name of the property used to configure ping timeout in ms.
      */
-    private final static String PING_TIMEOUT_PNAME = "PING_TIMEOUT";
+    public final static String PING_TIMEOUT_PNAME = "PING_TIMEOUT";
 
     /**
      * The name of the property which configures {@link #pingThreshold}.
      */
-    private final static String PING_THRESHOLD_PNAME = "PING_THRESHOLD";
+    public final static String PING_THRESHOLD_PNAME = "PING_THRESHOLD";
 
     /**
      * The name of the property which configures {@link #processingTimeLimit}.
      */
-    private final static String PROCESSING_TIME_LIMIT_PNAME
+    public final static String PROCESSING_TIME_LIMIT_PNAME
         = "PROCESSING_TIME_LIMIT";
 
     /**


### PR DESCRIPTION
This PR reduces the size of XMPP component's packet processor pool to 1 in order to avoid out of order processing(in parallel). An error message will be logged if the time limit is exceeded(100 ms by default).