### PR TITLE
Shutdown thread pool when EventAdminImpl bundle is stopped.

### DIFF
--- a/src/main/java/org/jitsi/eventadmin/EventAdminImpl.java
+++ b/src/main/java/org/jitsi/eventadmin/EventAdminImpl.java
@@ -122,6 +122,7 @@ public class EventAdminImpl
     public void stop(BundleContext ctx)
     {
         ctx.removeServiceListener(this);
+        executor.shutdown();
     }
 
     /**


### PR DESCRIPTION
The presence of non-demon thread from this pool prevents video bridge process from exist when shutdown is requested and all conferences completed.