### PR TITLE
generic version rest endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
   <packaging>jar</packaging>
   <properties>
     <jetty.version>9.4.15.v20190215</jetty.version>
+    <jersey.version>2.29</jersey.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <smack.version>4.2.4-47d17fc</smack.version>
   </properties>
@@ -73,6 +74,36 @@
       <artifactId>smack-tcp</artifactId>
       <version>${smack.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.containers</groupId>
+      <artifactId>jersey-container-jetty-http</artifactId>
+      <version>${jersey.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.containers</groupId>
+      <artifactId>jersey-container-servlet</artifactId>
+      <version>${jersey.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.inject</groupId>
+      <artifactId>jersey-hk2</artifactId>
+      <version>${jersey.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
+      <version>${jersey.version}</version>
+    </dependency>
+    <!-- jersey relies on this version of javassist or we get hk2
+    errors, but other libs (Powermock, at this time) also rely on
+    it but an older version, and that version is getting selected
+    which breaks jersey, so we explicitly depend on this here to
+    force the version -->
+    <dependency>
+      <groupId>org.javassist</groupId>
+      <artifactId>javassist</artifactId>
+      <version>3.22.0-CR2</version>
+    </dependency>
     <!-- org.jitsi -->
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -111,6 +142,24 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>2.0.31-beta</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.test-framework</groupId>
+      <artifactId>jersey-test-framework-core</artifactId>
+      <version>${jersey.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.test-framework.providers</groupId>
+      <artifactId>jersey-test-framework-provider-jetty</artifactId>
+      <version>${jersey.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.test-framework.providers</groupId>
+      <artifactId>jersey-test-framework-provider-grizzly2</artifactId>
+      <version>${jersey.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/org/jitsi/osgi/OsgiServiceProvider.java
+++ b/src/main/java/org/jitsi/osgi/OsgiServiceProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.osgi;
+
+import org.osgi.framework.*;
+
+/**
+ * A generic class for providing an OSGI service based on a given
+ * {@link BundleContext} and service class
+ * @param <T> the service being provided
+ */
+public class OsgiServiceProvider<T>
+{
+    protected final BundleContext bundleContext;
+    protected final Class<T> typeClass;
+
+    public OsgiServiceProvider(BundleContext bundleContext, Class<T> typeClass)
+    {
+        this.bundleContext = bundleContext;
+        this.typeClass = typeClass;
+    }
+
+    public T get()
+    {
+        return ServiceUtils2.getService(bundleContext, typeClass);
+    }
+}

--- a/src/main/java/org/jitsi/osgi/VersionServiceProvider.java
+++ b/src/main/java/org/jitsi/osgi/VersionServiceProvider.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.osgi;
+
+import org.jitsi.utils.version.*;
+import org.osgi.framework.*;
+
+public class VersionServiceProvider extends OsgiServiceProvider<VersionService>
+{
+    public VersionServiceProvider(BundleContext bundleContext)
+    {
+        super(bundleContext, VersionService.class);
+    }
+}

--- a/src/main/java/org/jitsi/rest/Version.java
+++ b/src/main/java/org/jitsi/rest/Version.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.jitsi.rest;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/org/jitsi/rest/Version.java
+++ b/src/main/java/org/jitsi/rest/Version.java
@@ -1,0 +1,56 @@
+package org.jitsi.rest;
+
+import com.fasterxml.jackson.annotation.*;
+import org.jitsi.osgi.*;
+import org.jitsi.utils.version.*;
+
+import javax.inject.*;
+import javax.ws.rs.*;
+import javax.ws.rs.core.*;
+
+/**
+ * A generic version REST endpoint which pulls version information from
+ * a {@link VersionService}, if one is present.  Otherwise returns
+ * {@link Version#UNKNOWN_VERSION}
+ *
+ */
+@Path("/about/version")
+public class Version
+{
+    @Inject
+    protected VersionServiceProvider versionServiceProvider;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public VersionInfo getVersion()
+    {
+        VersionService versionService = versionServiceProvider.get();
+        if (versionService == null)
+        {
+            return UNKNOWN_VERSION;
+        }
+        org.jitsi.utils.version.Version version = versionService.getCurrentVersion();
+
+        return new VersionInfo(
+            version.getApplicationName(),
+            version.toString(),
+            System.getProperty("os.name")
+        );
+    }
+
+    static class VersionInfo {
+        @JsonProperty String name;
+        @JsonProperty String version;
+        @JsonProperty String os;
+
+        public VersionInfo() {}
+        public VersionInfo(String name, String version, String os)
+        {
+            this.name = name;
+            this.version = version;
+            this.os = os;
+        }
+    }
+
+    protected static VersionInfo UNKNOWN_VERSION = new VersionInfo("", "", "");
+}

--- a/src/test/java/org/jitsi/rest/VersionTest.java
+++ b/src/test/java/org/jitsi/rest/VersionTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.rest;
+
+import org.eclipse.jetty.http.*;
+import org.glassfish.hk2.utilities.binding.*;
+import org.glassfish.jersey.server.*;
+import org.glassfish.jersey.test.*;
+import org.jitsi.osgi.*;
+import org.jitsi.utils.version.*;
+import org.junit.*;
+
+import javax.ws.rs.core.*;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import static org.mockito.Mockito.*;
+
+public class VersionTest extends JerseyTest
+{
+    protected VersionServiceProvider versionServiceProvider;
+    protected VersionService versionService;
+    protected static final String BASE_URL = "/about/version";
+
+    @Override
+    protected Application configure()
+    {
+        versionServiceProvider = mock(VersionServiceProvider.class);
+        versionService = mock(VersionService.class);
+        when(versionServiceProvider.get()).thenReturn(versionService);
+
+        enable(TestProperties.LOG_TRAFFIC);
+        enable(TestProperties.DUMP_ENTITY);
+        return new ResourceConfig() {
+            {
+                register(new AbstractBinder()
+                {
+                    @Override
+                    protected void configure()
+                    {
+                        bind(versionServiceProvider).to(VersionServiceProvider.class);
+                    }
+                });
+                register(Version.class);
+            }
+        };
+    }
+
+    @Test
+    public void testVersion()
+    {
+        when(versionService.getCurrentVersion()).thenReturn(
+            new VersionImpl("appName", 2, 0)
+        );
+
+        Response resp = target(BASE_URL).request().get();
+        assertEquals(HttpStatus.OK_200, resp.getStatus());
+        Version.VersionInfo versionInfo = resp.readEntity(Version.VersionInfo.class);
+        assertEquals("appName", versionInfo.name);
+        assertEquals("2.0", versionInfo.version);
+    }
+
+    @Test
+    public void testNoVersionService()
+    {
+        when(versionServiceProvider.get()).thenReturn(null);
+        Response resp = target(BASE_URL).request().get();
+        assertEquals(HttpStatus.OK_200, resp.getStatus());
+        Version.VersionInfo versionInfo = resp.readEntity(Version.VersionInfo.class);
+        assertTrue(versionInfo.name.isEmpty());
+        assertTrue(versionInfo.version.isEmpty());
+        assertTrue(versionInfo.os.isEmpty());
+    }
+}


### PR DESCRIPTION
a rest resource under /about/version which polls any found
VersionService for version information.

this is the style the bridge uses and what i'm moving jicofo to, so moved this code out of the bridge and into jicoco for reuse.