### PR TITLE
Mask sensitive fields when dumping config output

### DIFF
--- a/jicoco-kotlin/src/main/kotlin/org/jitsi/config/ConfigExtensions.kt
+++ b/jicoco-kotlin/src/main/kotlin/org/jitsi/config/ConfigExtensions.kt
@@ -1,0 +1,25 @@
+package org.jitsi.config
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigValueFactory
+import org.jitsi.utils.ConfigUtils
+import java.util.regex.Pattern
+
+private fun shouldMask(pattern: Pattern?, key: String): Boolean {
+    pattern ?: return false
+    return pattern.matcher(key).find()
+}
+
+private const val MASK = "******"
+
+fun Config.mask(): Config {
+    // Or should this be held in the config itself?
+    val pattern =
+        Pattern.compile(ConfigUtils.PASSWORD_SYS_PROPS, Pattern.CASE_INSENSITIVE)
+    return entrySet().fold(this) { config, (key, _) ->
+        when {
+            shouldMask(pattern, key) -> config.withValue(key, ConfigValueFactory.fromAnyRef(MASK))
+            else -> config
+        }
+    }
+}

--- a/jicoco-kotlin/src/main/kotlin/org/jitsi/config/JitsiConfig.kt
+++ b/jicoco-kotlin/src/main/kotlin/org/jitsi/config/JitsiConfig.kt
@@ -16,19 +16,32 @@
 
 package org.jitsi.config
 
+import org.jitsi.utils.logging2.LoggerImpl
+
 /**
  * Creates and holds the [ConfigSource] instances for the legacy and new
  * config files.
  */
 class JitsiConfig {
     companion object {
+        private val logger = LoggerImpl(JitsiConfig::class.qualifiedName)
         //TODO: type these to ConfigSource once reload gets moved to interface
         val newConfig = NewConfig()
         val legacyConfig = LegacyConfig()
 
+        init {
+            dumpConfigs()
+        }
+
         fun reload() {
             newConfig.reload()
             legacyConfig.reload()
+            dumpConfigs()
+        }
+
+        private fun dumpConfigs() {
+            logger.debug {"Loaded legacy config:\n${legacyConfig.config.mask().root().render()}" }
+            logger.debug {"Loaded new config:\n${newConfig.config.mask().root().render()}" }
         }
     }
 }

--- a/jicoco-kotlin/src/main/kotlin/org/jitsi/config/LegacyConfigFileLoader.kt
+++ b/jicoco-kotlin/src/main/kotlin/org/jitsi/config/LegacyConfigFileLoader.kt
@@ -51,18 +51,14 @@ class LegacyConfigFileLoader {
                 val path = Paths.get(firstPathArg, *otherPathArgs)
                 val file = path.toFile()
                 if (!file.exists()) {
-                    logger.info("No legacy config file found")
-                    ConfigFactory.parseString("")
-                } else {
-                    val config = ConfigFactory.parseFile(file)
-                    logger.info("Found a legacy config file: \n ${config.root().render()}")
-                    config
+                    throw InvalidPathException(path.toString(), "path doesn't exist")
                 }
+                ConfigFactory.parseFile(file)
             } catch (e: InvalidPathException) {
-                logger.info("No legacy config file found")
+                logger.info("No legacy config file found: $e")
                 ConfigFactory.parseString("")
             } catch (e: NullPointerException) {
-                logger.info("No legacy config file found")
+                logger.info("No legacy config file found: $e")
                 ConfigFactory.parseString("")
             }
         }

--- a/jicoco-kotlin/src/main/kotlin/org/jitsi/config/LegacyConfigFileLoader.kt
+++ b/jicoco-kotlin/src/main/kotlin/org/jitsi/config/LegacyConfigFileLoader.kt
@@ -49,9 +49,15 @@ class LegacyConfigFileLoader {
                     throw InvalidPathException("", "null path")
                 }
                 val path = Paths.get(firstPathArg, *otherPathArgs)
-                val config = ConfigFactory.parseFile(path.toFile())
-                logger.info("Found a legacy config file: \n" + config.root().render())
-                config
+                val file = path.toFile()
+                if (!file.exists()) {
+                    logger.info("No legacy config file found")
+                    ConfigFactory.parseString("")
+                } else {
+                    val config = ConfigFactory.parseFile(file)
+                    logger.info("Found a legacy config file: \n ${config.root().render()}")
+                    config
+                }
             } catch (e: InvalidPathException) {
                 logger.info("No legacy config file found")
                 ConfigFactory.parseString("")

--- a/jicoco-kotlin/src/main/kotlin/org/jitsi/config/TypesafeConfigSource.kt
+++ b/jicoco-kotlin/src/main/kotlin/org/jitsi/config/TypesafeConfigSource.kt
@@ -34,7 +34,8 @@ open class TypesafeConfigSource(
     override val name: String,
     private val configLoader: () -> Config
 ) : ConfigSource {
-    private var config = configLoader()
+    internal var config = configLoader()
+        private set
 
     @Suppress("UNCHECKED_CAST")
     override fun <T : Any> getterFor(valueType: KClass<T>): (String) -> T {


### PR DESCRIPTION
@bgrozev I did this using the legacy field `ConfigUtils.PASSWORD_SYS_PROPS`, but the more I think about it, the more I think we should have a property in the config itself which defines the sensitive properties.  Some advantages of this approach:
1) We can have different sensitive fields per config
2) We don't have to worry about races to set the static `ConfigUtils.PASSWORD_SYS_PROPS` field in time before we load the config.

Let me know what you think.