### PR TITLE
chore: update org.igniterealtime.smack to 4.3.4

### DIFF
--- a/jicoco/pom.xml
+++ b/jicoco/pom.xml
@@ -32,7 +32,7 @@
     <jetty.version>9.4.15.v20190215</jetty.version>
     <jersey.version>2.30.1</jersey.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <smack.version>4.2.4-47d17fc</smack.version>
+    <smack.version>4.3.4</smack.version>
   </properties>
 
   <name>jicoco</name>

--- a/jicoco/src/main/java/org/jitsi/rest/AbstractJSONHandler.java
+++ b/jicoco/src/main/java/org/jitsi/rest/AbstractJSONHandler.java
@@ -83,13 +83,13 @@ public abstract class AbstractJSONHandler
      */
     protected static int getHttpStatusCodeForResultIq(IQ responseIQ)
     {
-        XMPPError.Condition condition = responseIQ.getError().getCondition();
+        StanzaError.Condition condition = responseIQ.getError().getCondition();
 
-        if (XMPPError.Condition.not_authorized.equals(condition))
+        if (StanzaError.Condition.not_authorized.equals(condition))
         {
             return HttpServletResponse.SC_UNAUTHORIZED;
         }
-        else if (XMPPError.Condition.service_unavailable.equals(
+        else if (StanzaError.Condition.service_unavailable.equals(
                 condition))
         {
             return HttpServletResponse.SC_SERVICE_UNAVAILABLE;

--- a/jicoco/src/main/java/org/jitsi/xmpp/component/ComponentBase.java
+++ b/jicoco/src/main/java/org/jitsi/xmpp/component/ComponentBase.java
@@ -572,7 +572,7 @@ public abstract class ComponentBase
 
                     IQ pingIq = IQUtils.convert(ping);
 
-                    logger.debug("Sending ping IQ: " + ping.toXML());
+                    logger.debug("Sending ping IQ: " + ping.toXML(null));
 
                     send(pingIq);
 

--- a/jicoco/src/main/java/org/jitsi/xmpp/mucclient/MucClient.java
+++ b/jicoco/src/main/java/org/jitsi/xmpp/mucclient/MucClient.java
@@ -295,7 +295,12 @@ public class MucClient
                 logger.warn("Closed on error:", e);
             }
 
-            @Override
+            /**
+             * The connection has reconnected successfully to the server. Connections will
+             * reconnect to the server when the previous socket connection was abruptly closed.
+             * @deprecated use {@link #connected(XMPPConnection)} or {@link #authenticated(XMPPConnection, boolean)} instead.
+             */
+            @Deprecated
             public void reconnectionSuccessful()
             {
                 logger.info("Reconnection successful.");
@@ -310,7 +315,16 @@ public class MucClient
                 }
             }
 
-            @Override
+            /**
+             * The connection will retry to reconnect in the specified number of seconds.
+             * <p>
+             * Note: This method is only called if {@link ReconnectionManager#isAutomaticReconnectEnabled()} returns true, i.e.
+             * only when the reconnection manager is enabled for the connection.
+             * </p>
+             *
+             * @param i remaining seconds before attempting a reconnection.
+             */
+            @Deprecated
             public void reconnectingIn(int i)
             {
                 mucs.values().forEach(MucWrapper::resetLastPresenceSent);
@@ -320,7 +334,7 @@ public class MucClient
                 }
             }
 
-            @Override
+            @Deprecated
             public void reconnectionFailed(Exception e)
             {
                 logger.warn("Reconnection failed: ", e);
@@ -532,7 +546,7 @@ public class MucClient
                     mucJid -> mucJid.toLowerCase().equals(fromJidStr)))
         {
             logger.warn("Received an IQ from a non-MUC member: " + fromJid);
-            return IQUtils.createError(iq, XMPPError.Condition.forbidden);
+            return IQUtils.createError(iq, StanzaError.Condition.forbidden);
         }
 
         IQListener iqListener = this.iqListener;
@@ -555,7 +569,7 @@ public class MucClient
                 responseIq
                     = IQUtils.createError(
                     iq,
-                    XMPPError.Condition.internal_server_error,
+                    StanzaError.Condition.internal_server_error,
                     e.getMessage());
             }
         }
@@ -569,7 +583,7 @@ public class MucClient
             responseIq
                 = IQUtils.createError(
                     iq,
-                    XMPPError.Condition.internal_server_error,
+                    StanzaError.Condition.internal_server_error,
                     "Unknown error");
         }
 

--- a/jicoco/src/main/java/org/jitsi/xmpp/util/IQUtils.java
+++ b/jicoco/src/main/java/org/jitsi/xmpp/util/IQUtils.java
@@ -62,7 +62,7 @@ public final class IQUtils
             org.jivesoftware.smack.packet.IQ smackIQ)
         throws Exception
     {
-        XmlStringBuilder xml = smackIQ.toXML();
+        XmlStringBuilder xml = smackIQ.toXML(null);
 
         SAXReader saxReader = new SAXReader();
         Document document = saxReader.read(new StringReader(xml.toString()));
@@ -107,7 +107,7 @@ public final class IQUtils
 
         IQ.Type type = iq.getType();
         org.jivesoftware.smack.packet.IQ smackIQ = null;
-        org.jivesoftware.smack.packet.XMPPError.Builder smackError = null;
+        org.jivesoftware.smack.packet.StanzaError.Builder smackError = null;
 
         if (iqProvider != null || iq.getError() != null)
         {
@@ -259,22 +259,22 @@ public final class IQUtils
 
     /**
      * Method overload for {@link #createError(
-     * org.jivesoftware.smack.packet.IQ, XMPPError.Condition, String)} with
+     * org.jivesoftware.smack.packet.IQ, StanzaError.Condition, String)} with
      * no error message text.
      *
-     * @see #createError(org.jivesoftware.smack.packet.IQ, XMPPError.Condition,
+     * @see #createError(org.jivesoftware.smack.packet.IQ, StanzaError.Condition,
      * String)
      */
     public static org.jivesoftware.smack.packet.IQ createError(
             org.jivesoftware.smack.packet.IQ    request,
-            XMPPError.Condition                 errorCondition)
+        StanzaError.Condition                 errorCondition)
     {
         return createError(request, errorCondition, null);
     }
 
     /**
-     * A shortcut for <tt>new XMPPError(request,
-     * new XMPPError(errorCondition, errorMessage));</tt>. Create error response
+     * A shortcut for <tt>new StanzaError(request,
+     * new StanzaError(errorCondition, errorMessage));</tt>. Create error response
      * to given <tt>request</tt> IQ.
      *
      * @param request the request IQ for which the error response will be
@@ -287,10 +287,10 @@ public final class IQUtils
      */
     public static org.jivesoftware.smack.packet.IQ createError(
             org.jivesoftware.smack.packet.IQ    request,
-            XMPPError.Condition                 errorCondition,
+        StanzaError.Condition                 errorCondition,
             String                              errorMessage)
     {
-        XMPPError.Builder error = XMPPError.getBuilder(errorCondition);
+        StanzaError.Builder error = StanzaError.getBuilder(errorCondition);
         if (errorMessage != null)
         {
             error.setDescriptiveEnText(errorMessage);
@@ -405,7 +405,7 @@ public final class IQUtils
     public static String responseToXML(
             org.jivesoftware.smack.packet.Stanza response)
     {
-        return response != null ? response.toXML().toString() : "(timeout)";
+        return response != null ? response.toXML(null).toString() : "(timeout)";
     }
 
     /** Prevents the initialization of new <tt>IQUtils</tt> instances. */


### PR DESCRIPTION
This PR updates smack to 4.3.4

There have been quite a few changes in smack, so I'm not 100% sure everything is correct.
The tests pass though.

Since `XMPPError` has been renamed I think it would make sense to wait until PRs for all repositories which use jicoco are ready as drafts before merging this.

I'd still like to ask for some feedback, because smack removed 3 methods. I've marked both as deprecated in the jicoco codebase as well. Is that correct or should these methods remain in jicoco anyway?