### PR TITLE
fix: Retries connection on connection closed till the muc client is

### DIFF
--- a/jicoco/src/main/java/org/jitsi/xmpp/mucclient/MucClient.java
+++ b/jicoco/src/main/java/org/jitsi/xmpp/mucclient/MucClient.java
@@ -292,6 +292,13 @@ public class MucClient
 
                 if (MucClient.this.connectRetry != null)
                 {
+                    // FIXME this is a workaround for an issue that can happen
+                    // during a short network problem (~20 secs) where requests
+                    // ont he client side timeout during it and xmpp server
+                    // tries to close the connection by sending </stream> which
+                    // reaches the client when the network is back. That makes
+                    // smack disconnect the connection and never retries
+
                     // if the connection was closed, we want to continue trying
                     // so we will trigger the reconnection logic again
                     // till we are connected and will relay on smack's reconnect

--- a/jicoco/src/main/java/org/jitsi/xmpp/mucclient/MucClient.java
+++ b/jicoco/src/main/java/org/jitsi/xmpp/mucclient/MucClient.java
@@ -289,6 +289,16 @@ public class MucClient
             public void connectionClosed()
             {
                 logger.info("Closed.");
+
+                if (MucClient.this.connectRetry != null)
+                {
+                    // if the connection was closed, we want to continue trying
+                    // so we will trigger the reconnection logic again
+                    // till we are connected and will relay on smack's reconnect
+                    MucClient.this.connectRetry.runRetryingTask(
+                        new SimpleRetryTask(
+                            0, 5000, true, getConnectAndLoginCallable()));
+                }
             }
 
             @Override
@@ -594,6 +604,7 @@ public class MucClient
         if (this.connectRetry != null)
         {
             this.connectRetry.cancel();
+            this.connectRetry = null;
         }
 
         if (this.executor != null)


### PR DESCRIPTION
stopped.

This fixes a problem where due to the timings and the origin of the
network problem while trying to reconnect a closing stream tag was
received from server (detected that client is offline) just after a
period of network disconnection and after it resumed whic closes the
xmpp connection and stops trying to reconnect.

JVB 2020-06-18 04:03:07.303 WARNING: [11052] org.jivesoftware.smack.AbstractXMPPConnection.callConnectionClosedOnErrorListener: Connection XMPPTCPConnection[jvb@auth.jvb.example.com/cnA7VGg-] (0) closed with error
java.net.SocketException: Connection reset
	at java.net.SocketInputStream.read(SocketInputStream.java:210)
	at java.net.SocketInputStream.read(SocketInputStream.java:141)
	at sun.security.ssl.InputRecord.readFully(InputRecord.java:465)
	at sun.security.ssl.InputRecord.readV3Record(InputRecord.java:593)
	at sun.security.ssl.InputRecord.read(InputRecord.java:532)
	at sun.security.ssl.SSLSocketImpl.readRecord(SSLSocketImpl.java:990)
	at sun.security.ssl.SSLSocketImpl.readDataRecord(SSLSocketImpl.java:948)
	at sun.security.ssl.AppInputStream.read(AppInputStream.java:105)
	at sun.nio.cs.StreamDecoder.readBytes(StreamDecoder.java:284)
	at sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:326)
	at sun.nio.cs.StreamDecoder.read(StreamDecoder.java:178)
	at java.io.InputStreamReader.read(InputStreamReader.java:184)
	at java.io.BufferedReader.read1(BufferedReader.java:210)
	at java.io.BufferedReader.read(BufferedReader.java:286)
	at org.xmlpull.mxp1.MXParser.fillBuf(MXParser.java:2992)
	at org.xmlpull.mxp1.MXParser.more(MXParser.java:3046)
	at org.xmlpull.mxp1.MXParser.nextImpl(MXParser.java:1144)
	at org.xmlpull.mxp1.MXParser.next(MXParser.java:1093)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader.parsePackets(XMPPTCPConnection.java:1248)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader.access$300(XMPPTCPConnection.java:1000)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader$1.run(XMPPTCPConnection.java:1016)
	at java.lang.Thread.run(Thread.java:748)
JVB 2020-06-18 04:03:07.304 WARNING: [11052] [hostname= id=shard] MucClient$1.connectionClosedOnError#295: Closed on error:
java.net.SocketException: Connection reset
	at java.net.SocketInputStream.read(SocketInputStream.java:210)
	at java.net.SocketInputStream.read(SocketInputStream.java:141)
	at sun.security.ssl.InputRecord.readFully(InputRecord.java:465)
	at sun.security.ssl.InputRecord.readV3Record(InputRecord.java:593)
	at sun.security.ssl.InputRecord.read(InputRecord.java:532)
	at sun.security.ssl.SSLSocketImpl.readRecord(SSLSocketImpl.java:990)
	at sun.security.ssl.SSLSocketImpl.readDataRecord(SSLSocketImpl.java:948)
	at sun.security.ssl.AppInputStream.read(AppInputStream.java:105)
	at sun.nio.cs.StreamDecoder.readBytes(StreamDecoder.java:284)
	at sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:326)
	at sun.nio.cs.StreamDecoder.read(StreamDecoder.java:178)
	at java.io.InputStreamReader.read(InputStreamReader.java:184)
	at java.io.BufferedReader.read1(BufferedReader.java:210)
	at java.io.BufferedReader.read(BufferedReader.java:286)
	at org.xmlpull.mxp1.MXParser.fillBuf(MXParser.java:2992)
	at org.xmlpull.mxp1.MXParser.more(MXParser.java:3046)
	at org.xmlpull.mxp1.MXParser.nextImpl(MXParser.java:1144)
	at org.xmlpull.mxp1.MXParser.next(MXParser.java:1093)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader.parsePackets(XMPPTCPConnection.java:1248)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader.access$300(XMPPTCPConnection.java:1000)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader$1.run(XMPPTCPConnection.java:1016)
	at java.lang.Thread.run(Thread.java:748)
JVB 2020-06-18 04:03:22.687 WARNING: [24211] [hostname= id=shard] MucClient$1.reconnectionFailed#326: Reconnection failed:
org.jivesoftware.smack.SmackException$NoResponseException: No response received within reply timeout. Timeout was 5000ms (~5s). While waiting for establishing TLS
	at org.jivesoftware.smack.SmackException$NoResponseException.newWith(SmackException.java:93)
	at org.jivesoftware.smack.SynchronizationPoint.checkForResponse(SynchronizationPoint.java:272)
	at org.jivesoftware.smack.SynchronizationPoint.checkIfSuccessOrWait(SynchronizationPoint.java:157)
	at org.jivesoftware.smack.SynchronizationPoint.checkIfSuccessOrWaitOrThrow(SynchronizationPoint.java:128)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection.connectInternal(XMPPTCPConnection.java:908)
	at org.jivesoftware.smack.AbstractXMPPConnection.connect(AbstractXMPPConnection.java:383)
	at org.jivesoftware.smack.ReconnectionManager$2.run(ReconnectionManager.java:289)
	at java.lang.Thread.run(Thread.java:748)
JVB 2020-06-18 04:03:33.088 INFO: [24216] org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader.parsePackets: XMPPTCPConnection[jvb@auth.jvb.example.com/cnA7VGg-] (0) received closing </stream> element. Server wants to terminate the connection, calling disconnect()

JVB 2020-06-18 04:03:38.088 WARNING: [24211] [hostname= id=shard] MucClient$1.reconnectionFailed#326: Reconnection failed:
org.jivesoftware.smack.SmackException$NoResponseException: No response received within reply timeout. Timeout was 5000ms (~5s). While waiting for establishing TLS
	at org.jivesoftware.smack.SmackException$NoResponseException.newWith(SmackException.java:93)
	at org.jivesoftware.smack.SynchronizationPoint.checkForResponse(SynchronizationPoint.java:272)
	at org.jivesoftware.smack.SynchronizationPoint.checkIfSuccessOrWait(SynchronizationPoint.java:157)
	at org.jivesoftware.smack.SynchronizationPoint.checkIfSuccessOrWaitOrThrow(SynchronizationPoint.java:128)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection.connectInternal(XMPPTCPConnection.java:908)
	at org.jivesoftware.smack.AbstractXMPPConnection.connect(AbstractXMPPConnection.java:383)
	at org.jivesoftware.smack.ReconnectionManager$2.run(ReconnectionManager.java:289)
	at java.lang.Thread.run(Thread.java:748)
JVB 2020-06-18 04:03:38.089 INFO: [24216] [hostname= id=shard] MucClient$1.connectionClosed#289: Closed.
JVB 2020-06-18 04:03:38.089 WARNING: [24215] org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketWriter.writePackets: Exception flushing queue during shutdown, ignore and continue
java.lang.NullPointerException
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketWriter.writePackets(XMPPTCPConnection.java:1474)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketWriter.access$3300(XMPPTCPConnection.java:1264)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketWriter$1.run(XMPPTCPConnection.java:1312)
	at java.lang.Thread.run(Thread.java:748)
JVB 2020-06-18 04:03:38.091 WARNING: [24215] org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketWriter.writePackets: Exception writing closing stream element
java.lang.NullPointerException
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketWriter.writePackets(XMPPTCPConnection.java:1484)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketWriter.access$3300(XMPPTCPConnection.java:1264)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketWriter$1.run(XMPPTCPConnection.java:1312)
	at java.lang.Thread.run(Thread.java:748)