### PR TITLE
fix: Retry login if already logged in.

### DIFF
--- a/jicoco/src/main/java/org/jitsi/xmpp/mucclient/MucClient.java
+++ b/jicoco/src/main/java/org/jitsi/xmpp/mucclient/MucClient.java
@@ -294,7 +294,7 @@ public class MucClient
                 {
                     // FIXME this is a workaround for an issue that can happen
                     // during a short network problem (~20 secs) where requests
-                    // ont he client side timeout during it and xmpp server
+                    // on the client side timeout during it and xmpp server
                     // tries to close the connection by sending </stream> which
                     // reaches the client when the network is back. That makes
                     // smack disconnect the connection and never retries
@@ -671,8 +671,11 @@ public class MucClient
                 return true;
             }
 
-            logger.info("Logging in.");
-            xmppConnection.login();
+            if (!xmppConnection.isAuthenticated())
+            {
+                logger.info("Logging in.");
+                xmppConnection.login();
+            }
 
             executor.shutdown();
 


### PR DESCRIPTION
There is a case on prosody restart where we can get in an endless loop
trying to login, when we are already logged in.
Getting:
SEVERE: [23] RetryStrategy$TaskRunner.run#198: org.jivesoftware.smack.SmackException$AlreadyLoggedInException: Client is already logged in

```
2020-07-09 12:16:01.455 INFO: [31] [hostname=localhost id=shard] MucClient$1.connected#268: Connected.
2020-07-09 12:16:01.652 INFO: [31] [hostname=localhost id=shard] MucClient$MucWrapper.join#777: Joined MUC: jvbbrewery@internal.auth.jitsi.example.com
2020-07-09 12:16:01.696 WARNING: [40] org.jivesoftware.smack.AbstractXMPPConnection.callConnectionClosedOnErrorListener: Connection XMPPTCPConnection[jvb@auth.jitsi.example.com/a126a69d-984d-4b4c-a37e-d08041232e73] (0) closed with error
java.io.EOFException: input contained no data
	at org.xmlpull.mxp1.MXParser.fillBuf(MXParser.java:3003)
	at org.xmlpull.mxp1.MXParser.more(MXParser.java:3046)
	at org.xmlpull.mxp1.MXParser.parseProlog(MXParser.java:1410)
	at org.xmlpull.mxp1.MXParser.nextImpl(MXParser.java:1395)
	at org.xmlpull.mxp1.MXParser.next(MXParser.java:1093)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader.parsePackets(XMPPTCPConnection.java:1248)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader.access$300(XMPPTCPConnection.java:1000)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader$1.run(XMPPTCPConnection.java:1016)
	at java.lang.Thread.run(Thread.java:748)
2020-07-09 12:16:01.704 WARNING: [40] [hostname=localhost id=shard] MucClient$1.connectionClosedOnError#314: Closed on error:
java.io.EOFException: input contained no data
	at org.xmlpull.mxp1.MXParser.fillBuf(MXParser.java:3003)
	at org.xmlpull.mxp1.MXParser.more(MXParser.java:3046)
	at org.xmlpull.mxp1.MXParser.parseProlog(MXParser.java:1410)
	at org.xmlpull.mxp1.MXParser.nextImpl(MXParser.java:1395)
	at org.xmlpull.mxp1.MXParser.next(MXParser.java:1093)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader.parsePackets(XMPPTCPConnection.java:1248)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader.access$300(XMPPTCPConnection.java:1000)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader$1.run(XMPPTCPConnection.java:1016)
	at java.lang.Thread.run(Thread.java:748)
2020-07-09 12:16:05.614 WARNING: [23] [hostname=localhost id=shard] MucClient.lambda$getConnectAndLoginCallable$8#669: [MucClient id=shard hostname=localhost] error connecting
org.jivesoftware.smack.XMPPException$StreamErrorException: invalid-namespace You can read more about the meaning of this stream error at http://xmpp.org/rfcs/rfc6120.html#streams-error-conditions
<stream:error><invalid-namespace xmlns='urn:ietf:params:xml:ns:xmpp-streams'/></stream:error>
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader.parsePackets(XMPPTCPConnection.java:1059)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader.access$300(XMPPTCPConnection.java:1000)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader$1.run(XMPPTCPConnection.java:1016)
	at java.lang.Thread.run(Thread.java:748)
2020-07-09 12:16:05.621 WARNING: [52] org.jivesoftware.smack.AbstractXMPPConnection.callConnectionClosedOnErrorListener: Connection XMPPTCPConnection[jvb@auth.jitsi.example.com/a126a69d-984d-4b4c-a37e-d08041232e73] (0) closed with error
org.jivesoftware.smack.XMPPException$StreamErrorException: invalid-namespace You can read more about the meaning of this stream error at http://xmpp.org/rfcs/rfc6120.html#streams-error-conditions
<stream:error><invalid-namespace xmlns='urn:ietf:params:xml:ns:xmpp-streams'/></stream:error>
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader.parsePackets(XMPPTCPConnection.java:1064)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader.access$300(XMPPTCPConnection.java:1000)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader$1.run(XMPPTCPConnection.java:1016)
	at java.lang.Thread.run(Thread.java:748)
2020-07-09 12:16:05.622 WARNING: [52] [hostname=localhost id=shard] MucClient$1.connectionClosedOnError#314: Closed on error:
org.jivesoftware.smack.XMPPException$StreamErrorException: invalid-namespace You can read more about the meaning of this stream error at http://xmpp.org/rfcs/rfc6120.html#streams-error-conditions
<stream:error><invalid-namespace xmlns='urn:ietf:params:xml:ns:xmpp-streams'/></stream:error>
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader.parsePackets(XMPPTCPConnection.java:1064)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader.access$300(XMPPTCPConnection.java:1000)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader$1.run(XMPPTCPConnection.java:1016)
	at java.lang.Thread.run(Thread.java:748)
2020-07-09 12:16:05.787 INFO: [50] [hostname=localhost id=shard] MucClient$1.connected#268: Connected.
2020-07-09 12:16:05.843 INFO: [50] [hostname=localhost id=shard] MucClient$MucWrapper.join#749: Leaving a MUC we already occupy.
2020-07-09 12:16:05.892 INFO: [50] [hostname=localhost id=shard] MucClient$MucWrapper.join#777: Joined MUC: jvbbrewery@internal.auth.jitsi.example.com
2020-07-09 12:16:10.615 INFO: [23] [hostname=localhost id=shard] MucClient.lambda$getConnectAndLoginCallable$8#674: Logging in.
2020-07-09 12:16:10.616 SEVERE: [23] RetryStrategy$TaskRunner.run#198: org.jivesoftware.smack.SmackException$AlreadyLoggedInException: Client is already logged in
org.jivesoftware.smack.SmackException$AlreadyLoggedInException: Client is already logged in
	at org.jivesoftware.smack.tcp.XMPPTCPConnection.throwAlreadyLoggedInExceptionIfAppropriate(XMPPTCPConnection.java:371)
	at org.jivesoftware.smack.AbstractXMPPConnection.login(AbstractXMPPConnection.java:487)
	at org.jivesoftware.smack.AbstractXMPPConnection.login(AbstractXMPPConnection.java:448)
	at org.jitsi.xmpp.mucclient.MucClient.lambda$getConnectAndLoginCallable$8(MucClient.java:675)
	at org.jitsi.retry.RetryStrategy$TaskRunner.run(RetryStrategy.java:193)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```