### PR TITLE
Config source wrapper

### DIFF
--- a/jicoco-config/pom.xml
+++ b/jicoco-config/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>jitsi-metaconfig</artifactId>
-            <version>1.0</version>
+            <version>ab50680335</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/jicoco-config/src/main/kotlin/org/jitsi/config/ConfigSourceWrapper.kt
+++ b/jicoco-config/src/main/kotlin/org/jitsi/config/ConfigSourceWrapper.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.config
+
+import org.jitsi.metaconfig.ConfigSource
+import kotlin.reflect.KType
+
+/**
+ * A wrapper around a [ConfigSource] that allows changing the underlying
+ * [ConfigSource] at any time.  We use this in [JitsiConfig] so that test
+ * code can swap out the underlying [ConfigSource].
+ */
+class ConfigSourceWrapper(
+    var innerSource: ConfigSource
+) : ConfigSource {
+
+    override val name: String
+        get() = innerSource.name
+
+    override fun getterFor(type: KType): (String) -> Any =
+        innerSource.getterFor(type)
+}

--- a/jicoco-config/src/main/kotlin/org/jitsi/config/JitsiConfig.kt
+++ b/jicoco-config/src/main/kotlin/org/jitsi/config/JitsiConfig.kt
@@ -36,7 +36,9 @@ class JitsiConfig {
         /**
          * The 'new' [ConfigSource] that should be used by configuration properties.  Able to be changed for testing.
          */
-        var newConfig = TypesafeConfig
+        private val _newConfig: ConfigSourceWrapper = ConfigSourceWrapper(TypesafeConfig)
+        val newConfig: ConfigSource
+            get() = _newConfig
 
         /**
          * A [ConfigurationService] which can be installed via OSGi for legacy code which still requires it.
@@ -53,6 +55,16 @@ class JitsiConfig {
         /**
          * The 'legacy' [ConfigSource] that should be used by configuration properties.  Able to be changed for testing.
          */
-        var legacyConfig = SipCommunicatorPropsConfigSource
+        private val _legacyConfig: ConfigSourceWrapper = ConfigSourceWrapper(SipCommunicatorPropsConfigSource)
+        val legacyConfig: ConfigSource
+            get() = _legacyConfig
+
+        fun useDebugNewConfig(config: ConfigSource) {
+            _newConfig.innerSource = config
+        }
+
+        fun useDebugLegacyConfig(config: ConfigSource) {
+            _legacyConfig.innerSource = config
+        }
     }
 }

--- a/jicoco-test-kotlin/pom.xml
+++ b/jicoco-test-kotlin/pom.xml
@@ -36,8 +36,13 @@
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>jitsi-utils-kotlin</artifactId>
-            <version>${jitsi-utils.version}</version>
+            <artifactId>jicoco-config</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe</groupId>
+            <artifactId>config</artifactId>
+            <version>1.3.4</version>
         </dependency>
         <dependency>
             <groupId>io.kotlintest</groupId>

--- a/jicoco-test-kotlin/src/main/kotlin/org/jitsi/config/ConfigTestHelpers.kt
+++ b/jicoco-test-kotlin/src/main/kotlin/org/jitsi/config/ConfigTestHelpers.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.config
+
+import com.typesafe.config.ConfigFactory
+import java.io.StringReader
+import java.util.Properties
+
+inline fun useLegacyConfig(props: String, block: () -> Unit) =
+    useLegacyConfig("legacy", props, block)
+
+inline fun useLegacyConfig(name: String, props: String, block: () -> Unit) {
+    setLegacyConfig(props = props, name = name)
+    block()
+    setLegacyConfig("")
+}
+
+inline fun useNewConfig(config: String, loadDefaults: Boolean, block: () -> Unit) =
+    useNewConfig("new", config, loadDefaults, block)
+
+inline fun useNewConfig(name: String, config: String, loadDefaults: Boolean, block: () -> Unit) {
+    setNewConfig(config, loadDefaults, name)
+    block()
+    setNewConfig("", false)
+}
+
+inline fun useNewConfig(config: String, block: () -> Unit) =
+    useNewConfig(config, false, block)
+
+
+fun setNewConfig(config: String, loadDefaults: Boolean, name: String = "new") {
+    JitsiConfig.useDebugNewConfig(
+        TypesafeConfigSource(
+            name,
+            ConfigFactory.parseString(config).run { if (loadDefaults) withFallback(ConfigFactory.load()) else this }
+        )
+    )
+}
+
+fun setLegacyConfig(props: String, name: String = "legacy") {
+    JitsiConfig.useDebugLegacyConfig(
+        ConfigurationServiceConfigSource(
+            name,
+            TestReadOnlyConfigurationService(Properties().apply { load(StringReader(props)) })
+        )
+    )
+}

--- a/jicoco-test-kotlin/src/main/kotlin/org/jitsi/config/ConfigTestHelpers.kt
+++ b/jicoco-test-kotlin/src/main/kotlin/org/jitsi/config/ConfigTestHelpers.kt
@@ -20,18 +20,40 @@ import com.typesafe.config.ConfigFactory
 import java.io.StringReader
 import java.util.Properties
 
+/**
+ * Execute the given [block] using the props defined by [props] as a legacy
+ * [org.jitsi.metaconfig.ConfigSource] with name "legacy".  Resets the legacy
+ * config to empty after [block] is executed.
+ */
 inline fun useLegacyConfig(props: String, block: () -> Unit) =
     useLegacyConfig("legacy", props, block)
 
+/**
+ * Execute the given [block] using the props defined by [props] as a legacy
+ * [org.jitsi.metaconfig.ConfigSource] with name [name].  Resets the legacy
+ * config to empty after [block] is executed.
+ */
 inline fun useLegacyConfig(name: String, props: String, block: () -> Unit) {
     setLegacyConfig(props = props, name = name)
     block()
     setLegacyConfig("")
 }
 
+/**
+ * Execute the given [block] using the config defined by [config] as a new
+ * [org.jitsi.metaconfig.ConfigSource], falling back to the defaults if
+ * [loadDefaults] is true, with name "new".  Resets the new config to empty
+ * after [block] is executed.
+ */
 inline fun useNewConfig(config: String, loadDefaults: Boolean, block: () -> Unit) =
     useNewConfig("new", config, loadDefaults, block)
 
+/**
+ * Execute the given [block] using the config defined by [config] as a new
+ * [org.jitsi.metaconfig.ConfigSource], falling back to the defaults if
+ * [loadDefaults] is true, with name [name].  Resets the new config to empty
+ * after [block] is executed.
+ */
 inline fun useNewConfig(name: String, config: String, loadDefaults: Boolean, block: () -> Unit) {
     setNewConfig(config, loadDefaults, name)
     block()
@@ -42,6 +64,11 @@ inline fun useNewConfig(config: String, block: () -> Unit) =
     useNewConfig(config, false, block)
 
 
+/**
+ * Creates a [TypesafeConfigSource] using the parsed value of [config] and
+ * defaults in reference.conf if [loadDefaults] is set with name [name] and
+ * sets it as the underlying source of [JitsiConfig.newConfig]
+ */
 fun setNewConfig(config: String, loadDefaults: Boolean, name: String = "new") {
     JitsiConfig.useDebugNewConfig(
         TypesafeConfigSource(
@@ -51,6 +78,10 @@ fun setNewConfig(config: String, loadDefaults: Boolean, name: String = "new") {
     )
 }
 
+/**
+ * Creates a [ReadOnlyConfigurationService] using the parsed value of [props]
+ * with name [name] and sets it as the underlying source of [JitsiConfig.legacyConfig]
+ */
 fun setLegacyConfig(props: String, name: String = "legacy") {
     JitsiConfig.useDebugLegacyConfig(
         ConfigurationServiceConfigSource(

--- a/jicoco-test-kotlin/src/main/kotlin/org/jitsi/config/ConfigTestHelpers.kt
+++ b/jicoco-test-kotlin/src/main/kotlin/org/jitsi/config/ConfigTestHelpers.kt
@@ -57,7 +57,7 @@ inline fun useNewConfig(config: String, loadDefaults: Boolean, block: () -> Unit
 inline fun useNewConfig(name: String, config: String, loadDefaults: Boolean, block: () -> Unit) {
     setNewConfig(config, loadDefaults, name)
     block()
-    setNewConfig("", false)
+    setNewConfig("", true)
 }
 
 inline fun useNewConfig(config: String, block: () -> Unit) =

--- a/jicoco-test-kotlin/src/main/kotlin/org/jitsi/config/TestReadOnlyConfigurationService.kt
+++ b/jicoco-test-kotlin/src/main/kotlin/org/jitsi/config/TestReadOnlyConfigurationService.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.config
+
+import java.util.Properties
+
+class TestReadOnlyConfigurationService(
+    override var properties: Properties = Properties()
+) : AbstractReadOnlyConfigurationService() {
+
+    val props: Properties
+        get() = properties
+
+    override fun reloadConfiguration() {}
+}


### PR DESCRIPTION
This PR changes the way we hold on to `ConfigSource`s in `JitsiConfig`.  Before, we held a source directly in a `var` and, when testing, would merely re-assign the var.  This doesn't work when a property gets initialized before we have a chance to swap in the config we want (which can often be the case when config classes are held as static members).  This PR changes `JitsiConfig` to use a wrapper around a source, such that a 'stale' `ConfigSource` reference won't cause an issue when testing.

It also defines a set of helpers to create and re-assign the underlying configuration sources for legacy and new config for the purposes of testing.