### PR TITLE
remove kotlintest dep

### DIFF
--- a/jicoco-test-kotlin/pom.xml
+++ b/jicoco-test-kotlin/pom.xml
@@ -45,11 +45,6 @@
             <version>1.3.4</version>
         </dependency>
         <dependency>
-            <groupId>io.kotlintest</groupId>
-            <artifactId>kotlintest-runner-junit5</artifactId>
-            <version>3.4.2</version>
-        </dependency>
-        <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib-jdk8</artifactId>
             <version>${kotlin.version}</version>


### PR DESCRIPTION
I think I originally put this here as a common place to bring in the test lib dependency, but in practice I'm not sure that makes sense--a breaking change would then require updating everything which depended on it at once and it's just not that critical that all repos are on the same test version. 