### PR TITLE
Port AbstractJettyBundleActivator to new config

### DIFF
--- a/jicoco/pom.xml
+++ b/jicoco/pom.xml
@@ -204,8 +204,8 @@
                   </goals>
                   <configuration>
                       <sourceDirs>
-                          <source>src/main/java</source>
                           <source>src/main/kotlin</source>
+                          <source>src/main/java</source>
                       </sourceDirs>
                   </configuration>
               </execution>
@@ -215,6 +215,12 @@
                   <goals>
                       <goal>test-compile</goal>
                   </goals>
+                  <configuration>
+                      <sourceDirs>
+                          <source>src/test/kotlin</source>
+                          <source>src/test/java</source>
+                      </sourceDirs>
+                  </configuration>
               </execution>
           </executions>
           <configuration>
@@ -224,17 +230,25 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>3.8.1</version>
         <executions>
             <execution>
-                <id>compile</id>
+                <id>default-compile</id>
+                <phase>none</phase>
+            </execution>
+            <execution>
+                <id>default-testCompile</id>
+                <phase>none</phase>
+            </execution>
+            <execution>
+                <id>java-compile</id>
                 <phase>compile</phase>
                 <goals>
                     <goal>compile</goal>
                 </goals>
             </execution>
             <execution>
-                <id>testCompile</id>
+                <id>java-test-compile</id>
                 <phase>test-compile</phase>
                 <goals>
                     <goal>testCompile</goal>

--- a/jicoco/pom.xml
+++ b/jicoco/pom.xml
@@ -136,6 +136,11 @@
       <artifactId>jitsi-utils</artifactId>
       <version>${jitsi-utils.version}</version>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>jicoco-config</artifactId>
+      <version>${project.version}</version>
+    </dependency>
     <!-- test -->
     <dependency>
       <groupId>junit</groupId>

--- a/jicoco/src/main/java/org/jitsi/rest/AbstractJettyBundleActivator.java
+++ b/jicoco/src/main/java/org/jitsi/rest/AbstractJettyBundleActivator.java
@@ -119,6 +119,12 @@ public abstract class AbstractJettyBundleActivator
         this.config = new JettyBundleActivatorConfig(legacyPropertyPrefix, newPropertyPrefix);
     }
 
+    protected AbstractJettyBundleActivator(
+        String legacyPropertyPrefix)
+    {
+        this(legacyPropertyPrefix, "");
+    }
+
     /**
      * Notifies this {@code AbstractJettyBundleActivator} that a new Jetty
      * {@code Server} instance was initialized and started in a specific

--- a/jicoco/src/main/java/org/jitsi/rest/AbstractJettyBundleActivator.java
+++ b/jicoco/src/main/java/org/jitsi/rest/AbstractJettyBundleActivator.java
@@ -261,7 +261,7 @@ public abstract class AbstractJettyBundleActivator
         else
         {
             // HTTPS
-            File sslContextFactoryKeyStoreFile = Paths.get(config.getKeyStorePath()).toFile();
+            File sslContextFactoryKeyStoreFile = Paths.get(Objects.requireNonNull(config.getKeyStorePath())).toFile();
             SslContextFactory sslContextFactory = new SslContextFactory();
 
             /* Mozilla Guideline v5.4, Jetty 9.4.15, intermediate configuration

--- a/jicoco/src/main/java/org/jitsi/rest/AbstractJettyBundleActivator.java
+++ b/jicoco/src/main/java/org/jitsi/rest/AbstractJettyBundleActivator.java
@@ -18,6 +18,7 @@ package org.jitsi.rest;
 import org.eclipse.jetty.server.*;
 import org.eclipse.jetty.server.handler.*;
 import org.eclipse.jetty.util.ssl.*;
+import org.jetbrains.annotations.*;
 import org.jitsi.osgi.*;
 import org.jitsi.service.configuration.*;
 import org.jitsi.utils.*;
@@ -26,6 +27,7 @@ import org.osgi.framework.*;
 
 import java.io.*;
 import java.lang.reflect.*;
+import java.nio.file.*;
 import java.util.*;
 
 /**
@@ -37,50 +39,6 @@ import java.util.*;
 public abstract class AbstractJettyBundleActivator
     implements BundleActivator
 {
-    /**
-     * The name of the {@code ConfigurationService} and/or {@code System}
-     * property which specifies the Jetty HTTP server host.
-     */
-    public static final String JETTY_HOST_PNAME = ".jetty.host";
-
-    /**
-     * The name of the {@code ConfigurationService} and/or {@code System}
-     * property which specifies the Jetty HTTP server port. The default value is
-     * {@code 8080}.
-     */
-    public static final String JETTY_PORT_PNAME = ".jetty.port";
-
-    /**
-     * The name of the {@code ConfigurationService} and/or {@code System}
-     * property which specifies the keystore password to be utilized by
-     * {@code SslContextFactory} when Jetty serves over HTTPS.
-     */
-    static final String JETTY_SSLCONTEXTFACTORY_KEYSTOREPASSWORD
-        = ".jetty.sslContextFactory.keyStorePassword";
-
-    /**
-     * The name of the {@code ConfigurationService} and/or {@code System}
-     * property which specifies the keystore path to be utilized by
-     * {@code SslContextFactory} when Jetty serves over HTTPS.
-     */
-    static final String JETTY_SSLCONTEXTFACTORY_KEYSTOREPATH
-        = ".jetty.sslContextFactory.keyStorePath";
-
-    /**
-     * The name of the {@code ConfigurationService} and/or {@code System}
-     * property which specifies whether client certificate authentication is to
-     * be required by {@code SslContextFactory} when Jetty serves over HTTPS.
-     */
-    static final String JETTY_SSLCONTEXTFACTORY_NEEDCLIENTAUTH
-        = ".jetty.sslContextFactory.needClientAuth";
-
-    /**
-     * The name of the {@code ConfigurationService} and/or {@code System}
-     * property which specifies the Jetty HTTPS server port. The default value
-     * is {@code 8443}.
-     */
-    public static final String JETTY_TLS_PORT_PNAME = ".jetty.tls.port";
-
     /**
      * The {@code Logger} used by the {@code AbstractJettyBundleActivator} class
      * and its instances to print debug information.
@@ -137,16 +95,9 @@ public abstract class AbstractJettyBundleActivator
     }
 
     /**
-     * The {@code ConfigurationService} which looks up values of configuration
-     * properties.
+     * The config instance
      */
-    protected ConfigurationService cfg;
-
-    /**
-     * The prefix of the names of {@code ConfigurationService} and/or
-     * {@code System} properties to be utilized by this instance.
-     */
-    protected final String propertyPrefix;
+    protected final JettyBundleActivatorConfig config;
 
     /**
      * The Jetty {@code Server} which provides an HTTP(S) interface.
@@ -156,13 +107,16 @@ public abstract class AbstractJettyBundleActivator
     /**
      * Initializes a new {@code AbstractJettyBundleActivator} instance.
      *
-     * @param propertyPrefix the prefix of the names of
-     * {@code ConfigurationService} and/or {@code System} properties to be
-     * utilized by the new instance
+     * @param legacyPropertyPrefix the prefix of the names of {@code ConfigurationService} and/or
+     *                             {@code System} properties to be utilized by the new instance
+     * @param newPropertyPrefix the prefix of the config property names in a new
+     *                          config file
      */
-    protected AbstractJettyBundleActivator(String propertyPrefix)
+    protected AbstractJettyBundleActivator(
+        String legacyPropertyPrefix,
+        String newPropertyPrefix)
     {
-        this.propertyPrefix = propertyPrefix;
+        this.config = new JettyBundleActivatorConfig(legacyPropertyPrefix, newPropertyPrefix);
     }
 
     /**
@@ -252,82 +206,6 @@ public abstract class AbstractJettyBundleActivator
     }
 
     /**
-     * Returns the value of a specific {@code boolean}
-     * {@code ConfigurationService} or {@code System} property.
-     *
-     * @param property the name of the property
-     * @param defaultValue the value to be returned if {@code property} does not
-     * have any value assigned in either {@code ConfigurationService} or
-     * {@code System}
-     * @return the value of {@code property} in {@code ConfigurationService} or
-     * {@code System}
-     */
-    protected boolean getCfgBoolean(String property, boolean defaultValue)
-    {
-        return
-            ConfigUtils.getBoolean(cfg, prefixProperty(property), defaultValue);
-    }
-
-    /**
-     * Returns the value of a specific {@code int} {@code ConfigurationService}
-     * or {@code System} property.
-     *
-     * @param property the name of the property
-     * @param defaultValue the value to be returned if {@code property} does not
-     * have any value assigned in either {@code ConfigurationService} or
-     * {@code System}
-     * @return the value of {@code property} in {@code ConfigurationService} or
-     * {@code System}
-     */
-    protected int getCfgInt(String property, int defaultValue)
-    {
-        return ConfigUtils.getInt(cfg, prefixProperty(property), defaultValue);
-    }
-
-    /**
-     * Returns the value of a specific {@code String}
-     * {@code ConfigurationService} or {@code System} property.
-     *
-     * @param property the name of the property
-     * @param defaultValue the value to be returned if {@code property} does not
-     * have any value assigned in either {@code ConfigurationService} or
-     * {@code System}
-     * @return the value of {@code property} in {@code ConfigurationService} or
-     * {@code System}
-     */
-    protected String getCfgString(String property, String defaultValue)
-    {
-        return
-            ConfigUtils.getString(cfg, prefixProperty(property), defaultValue);
-    }
-
-    /**
-     * Gets the port on which the Jetty server is to listen for HTTP requests by
-     * default in the absence of a user specification through
-     * {@link #JETTY_PORT_PNAME}.
-     *
-     * @return the port on which the Jetty server is to listen for HTTP requests
-     * by default
-     */
-    protected int getDefaultPort()
-    {
-        return 8080;
-    }
-
-    /**
-     * Gets the port on which the Jetty server is to listen for HTTPS requests
-     * by default in the absence of a user specification through
-     * {@link #JETTY_TLS_PORT_PNAME}.
-     *
-     * @return the port on which the Jetty server is to listen for HTTPS
-     * requests by default
-     */
-    protected int getDefaultTlsPort()
-    {
-        return 8443;
-    }
-
-    /**
      * @return the port which the configuration specifies should be used by
      * this {@link AbstractJettyBundleActivator}, or -1 if the configuration
      * specifies that this instance should be disabled.
@@ -336,11 +214,11 @@ public abstract class AbstractJettyBundleActivator
     {
         if (isTls())
         {
-            return getCfgInt(JETTY_TLS_PORT_PNAME, getDefaultTlsPort());
+            return config.getTlsPort();
         }
         else
         {
-            return getCfgInt(JETTY_PORT_PNAME, getDefaultPort());
+            return config.getPort();
         }
     }
 
@@ -350,10 +228,7 @@ public abstract class AbstractJettyBundleActivator
      */
     protected boolean isTls()
     {
-        String sslContextFactoryKeyStorePath
-            = getCfgString(JETTY_SSLCONTEXTFACTORY_KEYSTOREPATH, null);
-
-        return sslContextFactoryKeyStorePath != null;
+        return config.getKeyStorePath() != null;
     }
 
     /**
@@ -371,40 +246,23 @@ public abstract class AbstractJettyBundleActivator
         throws Exception
     {
         HttpConfiguration httpCfg = new HttpConfiguration();
-        int tlsPort = getCfgInt(JETTY_TLS_PORT_PNAME, getDefaultTlsPort());
 
-        httpCfg.setSecurePort(tlsPort);
+        httpCfg.setSecurePort(config.getTlsPort());
         httpCfg.setSecureScheme("https");
 
-        String sslContextFactoryKeyStorePath
-            = getCfgString(JETTY_SSLCONTEXTFACTORY_KEYSTOREPATH, null);
         Connector connector;
 
         // If HTTPS is not enabled, serve over HTTP.
-        if (sslContextFactoryKeyStorePath == null)
+        if (!isTls())
         {
             // HTTP
-            connector
-                = new ServerConnector(
-                server,
-                new HttpConnectionFactory(httpCfg));
+            connector = new ServerConnector(server, new HttpConnectionFactory(httpCfg));
         }
         else
         {
             // HTTPS
-            File sslContextFactoryKeyStoreFile
-                = ConfigUtils.getAbsoluteFile(
-                sslContextFactoryKeyStorePath,
-                cfg);
+            File sslContextFactoryKeyStoreFile = Paths.get(config.getKeyStorePath()).toFile();
             SslContextFactory sslContextFactory = new SslContextFactory();
-            String sslContextFactoryKeyStorePassword
-                = getCfgString(
-                JETTY_SSLCONTEXTFACTORY_KEYSTOREPASSWORD,
-                null);
-            boolean sslContextFactoryNeedClientAuth
-                = getCfgBoolean(
-                JETTY_SSLCONTEXTFACTORY_NEEDCLIENTAUTH,
-                false);
 
             /* Mozilla Guideline v5.4, Jetty 9.4.15, intermediate configuration
                https://ssl-config.mozilla.org/#server=jetty&version=9.4.15&config=intermediate&guideline=5.4
@@ -436,15 +294,15 @@ public abstract class AbstractJettyBundleActivator
                 "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256");
 
             sslContextFactory.setRenegotiationAllowed(false);
-            if (sslContextFactoryKeyStorePassword != null)
+            if (config.getKeyStorePassword() != null)
             {
                 sslContextFactory.setKeyStorePassword(
-                    sslContextFactoryKeyStorePassword);
+                    config.getKeyStorePassword());
             }
             sslContextFactory.setKeyStorePath(
                 sslContextFactoryKeyStoreFile.getPath());
             sslContextFactory.setNeedClientAuth(
-                sslContextFactoryNeedClientAuth);
+                config.getNeedClientAuth());
 
             HttpConfiguration httpsCfg = new HttpConfiguration(httpCfg);
 
@@ -463,10 +321,8 @@ public abstract class AbstractJettyBundleActivator
         setPort(connector, getPort());
 
         // host
-        String host = getCfgString(JETTY_HOST_PNAME, null);
-
-        if (host != null)
-            setHost(connector, host);
+        if (config.getHost() != null)
+            setHost(connector, config.getHost());
 
         return connector;
     }
@@ -532,29 +388,6 @@ public abstract class AbstractJettyBundleActivator
     }
 
     /**
-     * Prefixes a specific {@code ConfigurationService} and/or {@code System}
-     * property name with {@link #propertyPrefix} if the property name in
-     * question is incomplete (i.e. starts with a dot).
-     *
-     * @param property the {@code ConfigurationService} and/or {@code System}
-     * property name to prefix
-     * @return a complete {@code ConfigurationService} and/or {@code System}
-     * property name equal to {@code property} if {@code property} is complete
-     * or derived from {@code property} by prefixing if {@code property} is
-     * incomplete
-     */
-    protected String prefixProperty(String property)
-    {
-        if (propertyPrefix != null
-                && property != null
-                && property.startsWith("."))
-        {
-            property = propertyPrefix + property;
-        }
-        return property;
-    }
-
-    /**
      * Sets the host on which a specific {@code Connector} is to listen for
      * incoming network connections.
      *
@@ -608,31 +441,15 @@ public abstract class AbstractJettyBundleActivator
     public void start(BundleContext bundleContext)
         throws Exception
     {
-        cfg
-            = ServiceUtils2.getService(
-                    bundleContext,
-                    ConfigurationService.class);
-
-        boolean started = false;
-
-        try
+        if (willStart(bundleContext))
         {
-            if (willStart(bundleContext))
-            {
-                doStart(bundleContext);
-                didStart(bundleContext);
-                started = true;
-            }
-            else
-            {
-                logger.info("Not starting the Jetty service for "
-                        + getClass().getName() + "(port=" + getPort() + ")");
-            }
+            doStart(bundleContext);
+            didStart(bundleContext);
         }
-        finally
+        else
         {
-            if (!started)
-                cfg = null;
+            logger.info("Not starting the Jetty service for "
+                    + getClass().getName() + "(port=" + getPort() + ")");
         }
     }
 
@@ -648,17 +465,10 @@ public abstract class AbstractJettyBundleActivator
     public void stop(BundleContext bundleContext)
         throws Exception
     {
-        try
+        if (willStop(bundleContext))
         {
-            if (willStop(bundleContext))
-            {
-                doStop(bundleContext);
-                didStop(bundleContext);
-            }
-        }
-        finally
-        {
-            cfg = null;
+            doStop(bundleContext);
+            didStop(bundleContext);
         }
     }
 

--- a/jicoco/src/main/kotlin/org/jitsi/rest/JettyBundleActivatorConfig.kt
+++ b/jicoco/src/main/kotlin/org/jitsi/rest/JettyBundleActivatorConfig.kt
@@ -32,7 +32,7 @@ class JettyBundleActivatorConfig(
      */
     val port: Int by config {
         "$legacyPropertyPrefix.jetty.port".from(JitsiConfig.legacyConfig)
-        "$newPropertyPrefix.jetty.port".from(JitsiConfig.newConfig)
+        "$newPropertyPrefix.port".from(JitsiConfig.newConfig)
         "default" { 8080 }
     }
 
@@ -41,7 +41,7 @@ class JettyBundleActivatorConfig(
      */
     val host: String? by optionalconfig {
         "$legacyPropertyPrefix.jetty.host".from(JitsiConfig.legacyConfig)
-        "$newPropertyPrefix.jetty.host".from(JitsiConfig.newConfig)
+        "$newPropertyPrefix.host".from(JitsiConfig.newConfig)
     }
 
     /**
@@ -50,7 +50,7 @@ class JettyBundleActivatorConfig(
      */
     val keyStorePath: String? by optionalconfig {
         "$legacyPropertyPrefix.jetty.keyStorePath".from(JitsiConfig.legacyConfig)
-        "$newPropertyPrefix.jetty.key-store-path".from(JitsiConfig.newConfig)
+        "$newPropertyPrefix.key-store-path".from(JitsiConfig.newConfig)
     }
 
     /**
@@ -59,7 +59,7 @@ class JettyBundleActivatorConfig(
      */
     val keyStorePassword: String? by optionalconfig {
         "$legacyPropertyPrefix.jetty.keyStorePassword".from(JitsiConfig.legacyConfig)
-        "$newPropertyPrefix.jetty.key-store-password".from(JitsiConfig.newConfig)
+        "$newPropertyPrefix.key-store-password".from(JitsiConfig.newConfig)
     }
 
     /**
@@ -68,7 +68,7 @@ class JettyBundleActivatorConfig(
      */
     val needClientAuth: Boolean by config {
         "$legacyPropertyPrefix.jetty.needClientAuth".from(JitsiConfig.legacyConfig)
-        "$newPropertyPrefix.jetty.need-client-auth".from(JitsiConfig.newConfig)
+        "$newPropertyPrefix.need-client-auth".from(JitsiConfig.newConfig)
         "default" { false }
     }
 
@@ -77,7 +77,7 @@ class JettyBundleActivatorConfig(
      */
     val tlsPort: Int by config {
         "$legacyPropertyPrefix.jetty.tls.port".from(JitsiConfig.legacyConfig)
-        "$newPropertyPrefix.jetty.tls-port".from(JitsiConfig.newConfig)
+        "$newPropertyPrefix.tls-port".from(JitsiConfig.newConfig)
         "default" { 8443 }
     }
 }

--- a/jicoco/src/main/kotlin/org/jitsi/rest/JettyBundleActivatorConfig.kt
+++ b/jicoco/src/main/kotlin/org/jitsi/rest/JettyBundleActivatorConfig.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.rest
+
+import org.jitsi.config.JitsiConfig
+import org.jitsi.metaconfig.config
+import org.jitsi.metaconfig.optionalconfig
+
+/**
+ * Configuration properties used by [AbstractJettyBundleActivator]
+ */
+class JettyBundleActivatorConfig(
+    private val legacyPropertyPrefix: String,
+    private val newPropertyPrefix: String
+) {
+    /**
+     * The port on which the Jetty server is to listen for HTTP requests
+     */
+    val port: Int by config {
+        "$legacyPropertyPrefix.jetty.port".from(JitsiConfig.legacyConfig)
+        "$newPropertyPrefix.jetty.port".from(JitsiConfig.newConfig)
+        "default" { 8080 }
+    }
+
+    /**
+     * The address on which the Jetty server will listen
+     */
+    val host: String? by optionalconfig {
+        "$legacyPropertyPrefix.jetty.host".from(JitsiConfig.legacyConfig)
+        "$newPropertyPrefix.jetty.host".from(JitsiConfig.newConfig)
+    }
+
+    /**
+     * The [java.security.KeyStore] path to be utilized by [org.eclipse.jetty.util.ssl.SslContextFactory]
+     * when Jetty serves over HTTPS.
+     */
+    val keyStorePath: String? by optionalconfig {
+        "$legacyPropertyPrefix.jetty.keyStorePath".from(JitsiConfig.legacyConfig)
+        "$newPropertyPrefix.jetty.key-store-path".from(JitsiConfig.newConfig)
+    }
+
+    /**
+     * The [java.security.KeyStore] password to be used by [org.eclipse.jetty.util.ssl.SslContextFactory]
+     * when Jetty serves over HTTPS
+     */
+    val keyStorePassword: String? by optionalconfig {
+        "$legacyPropertyPrefix.jetty.keyStorePassword".from(JitsiConfig.legacyConfig)
+        "$newPropertyPrefix.jetty.key-store-password".from(JitsiConfig.newConfig)
+    }
+
+    /**
+     * Whether or not client certificate authentication is to be required by
+     * [org.eclipse.jetty.util.ssl.SslContextFactory] when Jetty serves over HTTPS
+     */
+    val needClientAuth: Boolean by config {
+        "$legacyPropertyPrefix.jetty.needClientAuth".from(JitsiConfig.legacyConfig)
+        "$newPropertyPrefix.jetty.need-client-auth".from(JitsiConfig.newConfig)
+        "default" { false }
+    }
+
+    /**
+     * The port on which the Jetty server is to listen for HTTPS requests
+     */
+    val tlsPort: Int by config {
+        "$legacyPropertyPrefix.jetty.tls.port".from(JitsiConfig.legacyConfig)
+        "$newPropertyPrefix.jetty.tls-port".from(JitsiConfig.newConfig)
+        "default" { 8443 }
+    }
+}


### PR DESCRIPTION
A couple notes on this:

1. Technically this PR contains a breaking change: previously, if the `keyStorePath` value was not an absolute path, `AbstractJettyBundleActivator` would attempt to resolve it relative to the user's home directory and, if the user's home directory couldn't be determined, the current directory.  I removed that logic and it's now required to be an absolute path (**even for the legacy config file**).  I didn't replicate the old behavior because it was leveraging some features of the legacy `ConfigurationService`.  I did check our infra code and saw that we always set it as an absolute path.

1. Jicoco defined defaults for some of these values before and I preserved those, but I'm not sure it makes sense for them to stay there (as opposed to living in `reference.conf`)