### PR TITLE
Add support for 'Pattern'

### DIFF
--- a/jicoco-config/src/main/kotlin/org/jitsi/config/TypesafeConfigSource.kt
+++ b/jicoco-config/src/main/kotlin/org/jitsi/config/TypesafeConfigSource.kt
@@ -21,6 +21,7 @@ import com.typesafe.config.ConfigObject
 import org.jitsi.metaconfig.ConfigException
 import org.jitsi.metaconfig.ConfigSource
 import java.time.Duration
+import java.util.regex.Pattern
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.full.isSubtypeOf
@@ -52,6 +53,7 @@ class TypesafeConfigSource(
             typeOf<Duration>() -> wrap { key -> config.getDuration(key) }
             typeOf<ConfigObject>() -> wrap { key -> config.getObject(key) }
             typeOf<List<Config>>() -> wrap { key -> config.getConfigList(key) }
+            typeOf<Pattern>() -> wrap { key -> Pattern.compile(config.getString(key)) }
             else -> throw ConfigException.UnsupportedType("Type $type unsupported")
         }
     }

--- a/jicoco-config/src/main/kotlin/org/jitsi/config/TypesafeConfigSource.kt
+++ b/jicoco-config/src/main/kotlin/org/jitsi/config/TypesafeConfigSource.kt
@@ -73,6 +73,8 @@ class TypesafeConfigSource(
                 throw ConfigException.UnableToRetrieve.WrongType("Key '$key' in source '$name': ${e.message}")
             } catch (e: com.typesafe.config.ConfigException) {
                 throw ConfigException.UnableToRetrieve.NotFound(e.message ?: "typesafe exception: ${e::class}")
+            } catch (t: Throwable) {
+                throw ConfigException.UnableToRetrieve.Error(t)
             }
         }
     }

--- a/jicoco-config/src/test/kotlin/org/jitsi/config/TypesafeConfigSourceTest.kt
+++ b/jicoco-config/src/test/kotlin/org/jitsi/config/TypesafeConfigSourceTest.kt
@@ -19,12 +19,15 @@ package org.jitsi.config
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigObject
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import org.jitsi.metaconfig.ConfigException
 import org.jitsi.metaconfig.ConfigSource
 import java.time.Duration
+import java.util.regex.Pattern
 import kotlin.reflect.typeOf
 
 class TypesafeConfigSourceTest : ShouldSpec() {
@@ -114,9 +117,20 @@ class TypesafeConfigSourceTest : ShouldSpec() {
                     getValue<Color>("color") shouldBe Color.BLUE
                 }
             }
+            context("Pattern") {
+                withConfig("pattern = \"abc\"") {
+                    getValue<Pattern>("pattern").pattern() shouldBe "abc"
+                }
+                context("when the pattern is invalid") {
+                    withConfig("pattern = \"(\"") {
+                        shouldThrow<ConfigException.UnableToRetrieve.Error> {
+                            getValue<Pattern>("pattern").pattern()
+                        }
+                    }
+                }
+            }
         }
     }
-
 }
 
 private fun withConfig(configStr: String, block: ConfigScope.() -> Unit) {


### PR DESCRIPTION
I looked at adding support in `TypesafeConfigSource` for adding 'custom' getters dynamically to address both this case (add common support for a new type) and allowing repos to add support for their own custom types, but ultimately I thought it may not be good to have conversion logic separate from the definition of the property, as it felt a bit 'opaque', so I went this route and explicitly added support for this new type and the repos can continue to do the conversion logic in place (or in helper functions) using `convertFrom`.