### PR TITLE
use a custom config loader

### DIFF
--- a/jicoco-config/src/main/kotlin/org/jitsi/config/JitsiConfig.kt
+++ b/jicoco-config/src/main/kotlin/org/jitsi/config/JitsiConfig.kt
@@ -31,6 +31,10 @@ class JitsiConfig {
     companion object {
         val logger = LoggerImpl(JitsiConfig::class.simpleName)
 
+        init {
+            System.setProperty("config.strategy", "org.jitsi.config.JitsiConfigLoadingStrategy")
+        }
+
         /**
          * A [ConfigSource] loaded via [ConfigFactory].
          */

--- a/jicoco-config/src/main/kotlin/org/jitsi/config/JitsiConfigLoadingStrategy.kt
+++ b/jicoco-config/src/main/kotlin/org/jitsi/config/JitsiConfigLoadingStrategy.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.config
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigException
+import com.typesafe.config.ConfigFactory
+import com.typesafe.config.ConfigLoadingStrategy
+import com.typesafe.config.ConfigParseOptions
+import java.io.File
+import java.net.MalformedURLException
+import java.net.URL
+
+class JitsiConfigLoadingStrategy  : ConfigLoadingStrategy {
+    override fun parseApplicationConfig(parseOptions: ConfigParseOptions): Config {
+        println("====> IN CUSTOM LOADER")
+        val loader = parseOptions.classLoader ?: throw ConfigException.BugOrBroken(
+            "ClassLoader should have been set here; bug in ConfigFactory. " +
+                    "(You can probably work around this bug by passing in a class loader or calling " +
+                    "currentThread().setContextClassLoader() though.)")
+
+        // Load both any file specified by config.file, config.resource or config.url and any application
+        // resource
+        var specified = 0
+        val resource = System.getProperty("config.resource").also {
+            if (it != null) specified++
+        }
+        val file = System.getProperty("config.file").also {
+            if (it != null) specified++
+        }
+        val url = System.getProperty("config.url").also {
+            if (it != null) specified++
+        }
+        if (specified == 0) {
+            return ConfigFactory.parseResourcesAnySyntax("application")
+        } else {
+            // the override file/url/resource MUST be present or it's an error
+            val overrideOptions = parseOptions.setAllowMissing(false)
+            return when {
+                resource != null -> {
+                    ConfigFactory.parseResources(loader, resource.removePrefix("/"), overrideOptions)
+                        .withFallback(ConfigFactory.parseResourcesAnySyntax("application"))
+                        .resolve()
+                }
+                file != null -> {
+                    ConfigFactory.parseFile(File(file), overrideOptions)
+                        .withFallback(ConfigFactory.parseResourcesAnySyntax("application"))
+                        .resolve()
+                }
+                else -> {
+                    try {
+                        ConfigFactory.parseURL(URL(url), overrideOptions)
+                            .withFallback(ConfigFactory.parseResourcesAnySyntax("application"))
+                            .resolve()
+                    } catch (e: MalformedURLException) {
+                        throw ConfigException.Generic("Bad URL in config.url system property: '"
+                                + url + "': " + e.message, e)
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This aims to solve the same problem as https://github.com/jitsi/jicoco/pull/114, but in a different way.  Lightbend/config allows for a custom `ConfigLoadingStrategy` which handles only the loading of the application configs.  Since this is all we need, we can write a custom one to implement fallback behavior from a file passed via `-Dconfig.{file|resource|url}` to `application`, instead of replacement.

In the code I manually set the property in `JitsiConfig`, but it's possible we want to move that to infra scripts or something instead.