### PR TITLE
fallback to an application config file, even if a file has been passe…

### DIFF
--- a/jicoco-config/pom.xml
+++ b/jicoco-config/pom.xml
@@ -46,9 +46,9 @@
             <version>${jitsi-utils.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.typesafe</groupId>
+            <groupId>com.github.lightbend</groupId>
             <artifactId>config</artifactId>
-            <version>1.3.4</version>
+            <version>7c44daf5f5</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/jicoco-config/pom.xml
+++ b/jicoco-config/pom.xml
@@ -45,6 +45,9 @@
             <artifactId>jitsi-utils</artifactId>
             <version>${jitsi-utils.version}</version>
         </dependency>
+        <!-- NOTE: Temporarily use a 'custom' release from jitpack to get the fix we merged here.
+            Once https://github.com/lightbend/config/issues/702 has been resolved/the new version
+            released, we can go back to using the official release version-->
         <dependency>
             <groupId>com.github.lightbend</groupId>
             <artifactId>config</artifactId>

--- a/jicoco-config/src/main/kotlin/org/jitsi/config/JitsiConfig.kt
+++ b/jicoco-config/src/main/kotlin/org/jitsi/config/JitsiConfig.kt
@@ -41,7 +41,9 @@ class JitsiConfig {
                 // Fallback to application.(conf|json|properties)
                 .withFallback(ConfigFactory.parseResourcesAnySyntax("application"))
                 // Fallback to reference.(conf|json|properties)
-                .withFallback(ConfigFactory.defaultReference())
+                .withFallback(ConfigFactory.defaultReference()).also {
+                    println("loaded config: ${it.root().render()}")
+                }
         )
             private set
 

--- a/jicoco-config/src/main/kotlin/org/jitsi/config/JitsiConfig.kt
+++ b/jicoco-config/src/main/kotlin/org/jitsi/config/JitsiConfig.kt
@@ -94,8 +94,9 @@ class JitsiConfig {
         fun reloadNewConfig() {
             logger.info("Reloading the Typesafe config source (previously reloaded $numTypesafeReloads times).")
             ConfigFactory.invalidateCaches()
+            numTypesafeReloads++
             TypesafeConfig = TypesafeConfigSource(
-                "typesafe config (reloaded ${numTypesafeReloads++} times)",
+                "typesafe config (reloaded $numTypesafeReloads times)",
                 loadNewConfig()
             )
             _newConfig.innerSource = TypesafeConfig

--- a/jicoco-config/src/main/kotlin/org/jitsi/config/JitsiConfig.kt
+++ b/jicoco-config/src/main/kotlin/org/jitsi/config/JitsiConfig.kt
@@ -34,7 +34,15 @@ class JitsiConfig {
         /**
          * A [ConfigSource] loaded via [ConfigFactory].
          */
-        var TypesafeConfig: ConfigSource = TypesafeConfigSource("typesafe config", ConfigFactory.load())
+        var TypesafeConfig: ConfigSource = TypesafeConfigSource(
+            "typesafe config",
+            // Parse an application replacement (something passed via -Dconfig.file), if there is one
+            ConfigFactory.parseApplicationReplacement().orElse(ConfigFactory.empty())
+                // Fallback to application.(conf|json|properties)
+                .withFallback(ConfigFactory.parseResourcesAnySyntax("application"))
+                // Fallback to reference.(conf|json|properties)
+                .withFallback(ConfigFactory.defaultReference())
+        )
             private set
 
         private var numTypesafeReloads = 0

--- a/jicoco-config/src/main/kotlin/org/jitsi/config/JitsiConfig.kt
+++ b/jicoco-config/src/main/kotlin/org/jitsi/config/JitsiConfig.kt
@@ -86,9 +86,7 @@ class JitsiConfig {
                 // Fallback to application.(conf|json|properties)
                 .withFallback(ConfigFactory.parseResourcesAnySyntax("application"))
                 // Fallback to reference.(conf|json|properties)
-                .withFallback(ConfigFactory.defaultReference()).also {
-                    println("loaded config: ${it.root().render()}")
-                }
+                .withFallback(ConfigFactory.defaultReference())
         }
 
         fun reloadNewConfig() {


### PR DESCRIPTION
…d to -Dconfig.file

This fixes the problem we have in JVB, where we want to override config values used in libraries (e.g. ICE4J) in the jvb repo itself.  Without this, the file passed to `-Dconfig.file` _replaces_ any `application.conf` in the classpath.  The Lightbend config folks have not released the version needed to do this after a few weeks, and without this lonely dev servers break, so, if we want, we can do this in the meantime.  I have a JVB PR as well.