### PR TITLE
make a call to resolve when loading config

### DIFF
--- a/jicoco-config/src/main/kotlin/org/jitsi/config/JitsiConfig.kt
+++ b/jicoco-config/src/main/kotlin/org/jitsi/config/JitsiConfig.kt
@@ -18,6 +18,7 @@ package org.jitsi.config
 
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
+import com.typesafe.config.ConfigResolveOptions
 import org.jitsi.metaconfig.ConfigSource
 import org.jitsi.service.configuration.ConfigurationService
 import org.jitsi.utils.logging2.LoggerImpl
@@ -87,6 +88,7 @@ class JitsiConfig {
                 .withFallback(ConfigFactory.parseResourcesAnySyntax("application"))
                 // Fallback to reference.(conf|json|properties)
                 .withFallback(ConfigFactory.defaultReference())
+                .resolve()
         }
 
         fun reloadNewConfig() {


### PR DESCRIPTION
https://github.com/jitsi/jicoco/pull/118 Fixed an issue with overriding defaults in a lib, but it also moved away from calling `ConfigFactory#load` which called `Config#resolve` to resolve substitutions.  Since we're not calling that anymore, we need to call `resolve` explicitly.