### PR TITLE
Fix failures to re-login.

### DIFF
--- a/jicoco/src/main/java/org/jitsi/xmpp/mucclient/MucClient.java
+++ b/jicoco/src/main/java/org/jitsi/xmpp/mucclient/MucClient.java
@@ -358,11 +358,11 @@ public class MucClient
     }
 
     /**
-     * Whether the XMPP connection is currently connected.
+     * Whether the XMPP connection is currently connected (and authenticated).
      */
     boolean isConnected()
     {
-        return xmppConnection != null && xmppConnection.isConnected();
+        return xmppConnection != null && xmppConnection.isConnected() && xmppConnection.isAuthenticated();
     }
 
     /**


### PR DESCRIPTION
 This is a workaround for a failure to re-login we observe, in which
    Smack's state indicates that the XMPPConnection is connected, but is
    unable to login because the server did not indicate SASL support.