### PR TITLE
fix: Do not export all org.jitsi.* packages (includes classes from jitsi-utils).

### DIFF
--- a/jicoco/bnd.bnd
+++ b/jicoco/bnd.bnd
@@ -1,6 +1,0 @@
-Export-Package: org.jitsi.assertions,org.jitsi.cmd,org.jitsi.health,org.jitsi.meet,org.jitsi.rest,org.jitsi.retry,org.jitsi.xmpp,org.jitsi.shutdown
-Import-Package: *;version=!
-Bundle-SymbolicName: org.jitsi.jicoco
--noextraheaders: true
--snapshot: SNAPSHOT
--removeheaders: Require-Capability, Bundle-SCM

--- a/jicoco/bnd.bnd
+++ b/jicoco/bnd.bnd
@@ -1,4 +1,4 @@
-Export-Package: org.jitsi.*
+Export-Package: org.jitsi.assertions,org.jitsi.cmd,org.jitsi.health,org.jitsi.meet,org.jitsi.rest,org.jitsi.retry,org.jitsi.xmpp,org.jitsi.shutdown
 Import-Package: *;version=!
 Bundle-SymbolicName: org.jitsi.jicoco
 -noextraheaders: true


### PR DESCRIPTION
Nothing uses jicoco as a bundle