### PR TITLE
Added option to control sendServerVersion parameter of Jetty

### DIFF
--- a/jicoco/src/main/kotlin/org/jitsi/rest/JettyBundleActivatorConfig.kt
+++ b/jicoco/src/main/kotlin/org/jitsi/rest/JettyBundleActivatorConfig.kt
@@ -87,5 +87,15 @@ class JettyBundleActivatorConfig(
         "default" { 8443 }
     }
 
-    override fun toString() = "host=$host, port=$port, tlsPort=$tlsPort, isTls=$isTls, keyStorePath=$keyStorePath"
+    /**
+     * Whether Jetty server version should be sent in HTTP responses
+     */
+    val sendServerVersion: Boolean by config {
+        "$legacyPropertyPrefix.jetty.sendServerVersion".from(JitsiConfig.legacyConfig)
+        "$newPropertyPrefix.sendServerVersion".from(JitsiConfig.newConfig)
+        "default" { true }
+    }
+
+    override fun toString() = "host=$host, port=$port, tlsPort=$tlsPort, isTls=$isTls, keyStorePath=$keyStorePath, " +
+            "sendServerVersion=$sendServerVersion"
 }

--- a/jicoco/src/main/kotlin/org/jitsi/rest/JettyBundleActivatorConfig.kt
+++ b/jicoco/src/main/kotlin/org/jitsi/rest/JettyBundleActivatorConfig.kt
@@ -91,8 +91,7 @@ class JettyBundleActivatorConfig(
      * Whether Jetty server version should be sent in HTTP responses
      */
     val sendServerVersion: Boolean by config {
-        "$legacyPropertyPrefix.jetty.sendServerVersion".from(JitsiConfig.legacyConfig)
-        "$newPropertyPrefix.sendServerVersion".from(JitsiConfig.newConfig)
+        "$newPropertyPrefix.send-server-version".from(JitsiConfig.newConfig)
         "default" { true }
     }
 

--- a/jicoco/src/main/kotlin/org/jitsi/rest/JettyBundleActivatorConfig.kt
+++ b/jicoco/src/main/kotlin/org/jitsi/rest/JettyBundleActivatorConfig.kt
@@ -96,5 +96,5 @@ class JettyBundleActivatorConfig(
     }
 
     override fun toString() = "host=$host, port=$port, tlsPort=$tlsPort, isTls=$isTls, keyStorePath=$keyStorePath, " +
-            "sendServerVersion=$sendServerVersion"
+        "sendServerVersion=$sendServerVersion"
 }

--- a/jicoco/src/main/kotlin/org/jitsi/rest/JettyHelpers.kt
+++ b/jicoco/src/main/kotlin/org/jitsi/rest/JettyHelpers.kt
@@ -17,14 +17,19 @@
 
 package org.jitsi.rest
 
-import org.eclipse.jetty.server.*
+import org.eclipse.jetty.server.HttpConfiguration
+import org.eclipse.jetty.server.HttpConnectionFactory
+import org.eclipse.jetty.server.SecureRequestCustomizer
+import org.eclipse.jetty.server.Server
+import org.eclipse.jetty.server.ServerConnector
+import org.eclipse.jetty.server.SslConnectionFactory
 import org.eclipse.jetty.servlet.ServletContextHandler
 import org.eclipse.jetty.servlet.ServletHolder
 import org.eclipse.jetty.servlets.CrossOriginFilter
 import org.eclipse.jetty.util.ssl.SslContextFactory
 import org.jitsi.utils.getJavaVersion
 import java.nio.file.Paths
-import java.util.*
+import java.util.EnumSet
 import javax.servlet.DispatcherType
 
 /**


### PR DESCRIPTION
As I explained [here](https://community.jitsi.org/t/how-to-hide-jetty-version-from-responses/97677), I'd like to be able to hide the Jetty version from error responses. 

This PR adds this option to Jicoco.

I've tried it with [f8e9405198e0c20e8b0c82af7a65108809fef78e](https://github.com/jitsi/jicoco/commit/f8e9405198e0c20e8b0c82af7a65108809fef78e) and a [JVB 5390](https://github.com/jitsi/jitsi-videobridge/releases/tag/stable%2Fjitsi-meet_5390).

I didn't see Jetty version in responses as I expected when I set `org.jitsi.videobridge.rest.jetty.sendServerVersion=false` in JVB params.