### PR TITLE
Add getMucClientIds to MucClientManager

### DIFF
--- a/jicoco/src/main/java/org/jitsi/xmpp/mucclient/MucClientManager.java
+++ b/jicoco/src/main/java/org/jitsi/xmpp/mucclient/MucClientManager.java
@@ -357,6 +357,14 @@ public class MucClientManager
     }
 
     /**
+     * Return a list of ids for MUC client configs that have been added.
+     */
+    public List<String> getMucClientIds()
+    {
+        return new ArrayList<>(mucClients.keySet());
+    }
+
+    /**
      * Return the number of configured MUCs.
      */
     public long getMucCount()


### PR DESCRIPTION
This will enable `/colibri/muc-client/list` on jitsi-videobridge.

Ref: https://community.jitsi.org/t/list-added-muc-clients-on-videobridge/100268/6?u=shawn