### PR TITLE
Reconnection fixes

### DIFF
--- a/jicoco/src/main/java/org/jitsi/xmpp/mucclient/ConnectionStateListener.java
+++ b/jicoco/src/main/java/org/jitsi/xmpp/mucclient/ConnectionStateListener.java
@@ -18,7 +18,7 @@ package org.jitsi.xmpp.mucclient;
 
 import org.jetbrains.annotations.*;
 
-interface ConnectionStateListener
+public interface ConnectionStateListener
 {
     void connected(@NotNull MucClient mucClient);
 

--- a/jicoco/src/main/java/org/jitsi/xmpp/mucclient/ConnectionStateListener.java
+++ b/jicoco/src/main/java/org/jitsi/xmpp/mucclient/ConnectionStateListener.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright @ 2022 - present, 8x8 Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.jitsi.xmpp.mucclient;
+
+import org.jetbrains.annotations.*;
+
+interface ConnectionStateListener
+{
+    void connected(@NotNull MucClient mucClient);
+
+    void closed(@NotNull MucClient mucClient);
+
+    void closedOnError(@NotNull MucClient mucClient);
+
+    void reconnecting(@NotNull MucClient mucClient);
+
+    void reconnectionFailed(@NotNull MucClient mucClient);
+
+    void pingFailed(@NotNull MucClient mucClient);
+
+    void halfOpenDetected(@NotNull MucClient mucClient);
+
+    void halfOpenRecovered(@NotNull MucClient mucClient);
+}

--- a/jicoco/src/main/java/org/jitsi/xmpp/mucclient/MucClient.java
+++ b/jicoco/src/main/java/org/jitsi/xmpp/mucclient/MucClient.java
@@ -214,12 +214,17 @@ public class MucClient
         @Override
         public void reconnectingIn(int i)
         {
+            if (i == 0)
+            {
+                mucClientManager.reconnecting(MucClient.this);
+            }
             logger.info("Reconnecting in " + i);
         }
 
         @Override
         public void reconnectionFailed(Exception e)
         {
+            mucClientManager.reconnectionFailed(MucClient.this);
             logger.warn("Reconnection failed: ", e);
         }
     };
@@ -302,6 +307,7 @@ public class MucClient
             @Override
             public void connected(XMPPConnection xmppConnection)
             {
+                mucClientManager.connected(MucClient.this);
                 logger.info("Connected.");
             }
 
@@ -314,12 +320,14 @@ public class MucClient
             @Override
             public void connectionClosed()
             {
+                mucClientManager.closed(MucClient.this);
                 logger.info("Closed.");
             }
 
             @Override
             public void connectionClosedOnError(Exception e)
             {
+                mucClientManager.closedOnError(MucClient.this);
                 logger.warn("Closed on error:", e);
             }
         });
@@ -845,6 +853,7 @@ public class MucClient
         public void pingFailed()
         {
             logger.warn("Ping failed, the XMPP connection needs to reconnect.");
+            mucClientManager.pingFailed(MucClient.this);
 
             if (xmppConnection.isConnected() && xmppConnection.isAuthenticated())
             {
@@ -895,6 +904,7 @@ public class MucClient
 
         private void actOnFailure(@NotNull AbstractXMPPConnection xmppConnection)
         {
+            mucClientManager.halfOpenDetected(MucClient.this);
             if (hasFailedOnce)
             {
                 // Reset the state for the next re-connect
@@ -915,6 +925,7 @@ public class MucClient
             if (hasFailedOnce)
             {
                 hasFailedOnce = false;
+                mucClientManager.halfOpenRecovered(MucClient.this);
                 logger.warn("Recovered from a half-open state.");
             }
         }

--- a/jicoco/src/main/java/org/jitsi/xmpp/mucclient/MucClient.java
+++ b/jicoco/src/main/java/org/jitsi/xmpp/mucclient/MucClient.java
@@ -627,7 +627,7 @@ public class MucClient
             }
             catch(Exception t)
             {
-                logger.warn(MucClient.this + " error connecting", t);
+                logger.warn(" error connecting", t);
                 return true;
             }
 
@@ -916,6 +916,7 @@ public class MucClient
             {
                 // After the first failure, try to resolve the problem with an ugly hack instead of a re-connect.
                 hasFailedOnce = true;
+                logger.warn("Half-open XMPP connection detected, will try to unblock SmackReactor.");
                 tryToUnblockSmackReactor();
             }
         }

--- a/jicoco/src/main/java/org/jitsi/xmpp/mucclient/MucClient.java
+++ b/jicoco/src/main/java/org/jitsi/xmpp/mucclient/MucClient.java
@@ -627,7 +627,7 @@ public class MucClient
             }
             catch(Exception t)
             {
-                logger.warn(" error connecting", t);
+                logger.warn("Error connecting:", t);
                 return true;
             }
 

--- a/jicoco/src/main/java/org/jitsi/xmpp/mucclient/MucClient.java
+++ b/jicoco/src/main/java/org/jitsi/xmpp/mucclient/MucClient.java
@@ -884,6 +884,9 @@ public class MucClient
      * This is a hack to work around a bug observed in Smack 4.4.4 in which the network connection is lost, but the
      * XMPPConnection remain connected and authenticated, and the ping failed listener is never called. It is meant as
      * a last resort to prevent leaks.
+     *
+     * TODO: remove this when Smack is updated to include this fix:
+     * https://github.com/igniterealtime/Smack/pull/512
      */
     class HalfOpenConnectionPeriodicCheck
         extends PeriodicRunnable

--- a/jicoco/src/main/java/org/jitsi/xmpp/mucclient/MucClientManager.java
+++ b/jicoco/src/main/java/org/jitsi/xmpp/mucclient/MucClientManager.java
@@ -16,6 +16,7 @@
  */
 package org.jitsi.xmpp.mucclient;
 
+import org.jetbrains.annotations.*;
 import org.jitsi.service.configuration.*;
 import org.jitsi.utils.concurrent.*;
 import org.jitsi.utils.logging2.*;
@@ -36,7 +37,7 @@ import java.util.concurrent.*;
  *
  * @author Boris Grozev
  */
-public class MucClientManager
+public class MucClientManager implements ConnectionStateListener
 {
     /**
      * The {@link Logger} used by the {@link MucClientManager} class and its
@@ -85,6 +86,8 @@ public class MucClientManager
      */
     private final RecurringRunnableExecutor recurringRunnableExecutor = new RecurringRunnableExecutor();
 
+    List<ConnectionStateListener> connectionStateListeners = new CopyOnWriteArrayList<>();
+
     /**
      * Initializes a new {@link MucClientManager} instance.
      *
@@ -109,6 +112,16 @@ public class MucClientManager
         {
             this.features.addAll(Arrays.asList(features));
         }
+    }
+
+    public void addConnectionStateListener(ConnectionStateListener listener)
+    {
+        connectionStateListeners.add(listener);
+    }
+
+    public void removeConnectionStateListener(ConnectionStateListener listener)
+    {
+        connectionStateListeners.remove(listener);
     }
 
     /**
@@ -392,5 +405,77 @@ public class MucClientManager
                 .map(MucClient::getMucsJoinedCount)
                 .mapToInt(Integer::intValue)
                 .sum();
+    }
+
+    @Override
+    public void connected(@NotNull MucClient mucClient)
+    {
+        for (ConnectionStateListener listener : connectionStateListeners)
+        {
+            listener.connected(mucClient);
+        }
+    }
+
+    @Override
+    public void closed(@NotNull MucClient mucClient)
+    {
+        for (ConnectionStateListener listener : connectionStateListeners)
+        {
+            listener.closed(mucClient);
+        }
+    }
+
+    @Override
+    public void closedOnError(@NotNull MucClient mucClient)
+    {
+        for (ConnectionStateListener listener : connectionStateListeners)
+        {
+            listener.closedOnError(mucClient);
+        }
+    }
+
+    @Override
+    public void reconnecting(@NotNull MucClient mucClient)
+    {
+        for (ConnectionStateListener listener : connectionStateListeners)
+        {
+            listener.reconnecting(mucClient);
+        }
+    }
+
+    @Override
+    public void reconnectionFailed(@NotNull MucClient mucClient)
+    {
+        for (ConnectionStateListener listener : connectionStateListeners)
+        {
+            listener.reconnectionFailed(mucClient);
+        }
+    }
+
+    @Override
+    public void pingFailed(@NotNull MucClient mucClient)
+    {
+        for (ConnectionStateListener listener : connectionStateListeners)
+        {
+            listener.pingFailed(mucClient);
+        }
+    }
+
+    @Override
+    public void halfOpenDetected(@NotNull MucClient mucClient)
+    {
+        for (ConnectionStateListener listener : connectionStateListeners)
+        {
+            listener.halfOpenDetected(mucClient);
+        }
+    }
+
+    @Override
+    public void halfOpenRecovered(@NotNull MucClient mucClient)
+    {
+        for (ConnectionStateListener listener : connectionStateListeners)
+        {
+            listener.halfOpenRecovered(mucClient);
+        }
     }
 }


### PR DESCRIPTION
- fix: Increase the half-open check interval.
- hack: Try to unblock SmackReactor before triggering a re-connect.
- feat: Add an interface to expose connection state changes.
- log: Log the first time a half-open connection is detected.
- squash: Make the interface public.
