### PR TITLE
Implement all stub methods for FakeScheduledExecutorService.

### DIFF
--- a/jicoco-test-kotlin/src/main/kotlin/org/jitsi/test/concurrent/FakeScheduledExecutorService.kt
+++ b/jicoco-test-kotlin/src/main/kotlin/org/jitsi/test/concurrent/FakeScheduledExecutorService.kt
@@ -19,7 +19,9 @@ package org.jitsi.test.concurrent
 import org.jitsi.test.time.FakeClock
 import java.time.Duration
 import java.time.Instant
+import java.util.concurrent.Callable
 import java.util.concurrent.Delayed
+import java.util.concurrent.Future
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
@@ -28,7 +30,7 @@ import java.util.concurrent.TimeUnit
  * A fake [ScheduledExecutorService] which gives control over when scheduled tasks are run without requiring a
  * separate thread
  */
-abstract class FakeScheduledExecutorService : ScheduledExecutorService {
+class FakeScheduledExecutorService : ScheduledExecutorService {
     private var jobs = JobsTimeline()
     val clock: FakeClock = FakeClock()
 
@@ -124,6 +126,68 @@ abstract class FakeScheduledExecutorService : ScheduledExecutorService {
                 }
             }
         }
+    }
+
+    /* Methods required by ScheduledExecutorService, but not needed by our unit tests. */
+
+    override fun execute(command: Runnable) {
+        TODO("Not yet implemented")
+    }
+
+    override fun shutdown() {
+        TODO("Not yet implemented")
+    }
+
+    override fun shutdownNow(): MutableList<Runnable> {
+        TODO("Not yet implemented")
+    }
+
+    override fun isShutdown(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun isTerminated(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun awaitTermination(timeout: Long, unit: TimeUnit): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun <T : Any?> submit(task: Callable<T>): Future<T> {
+        TODO("Not yet implemented")
+    }
+
+    override fun <T : Any?> submit(task: Runnable, result: T): Future<T> {
+        TODO("Not yet implemented")
+    }
+
+    override fun submit(task: Runnable): Future<*> {
+        TODO("Not yet implemented")
+    }
+
+    override fun <T : Any?> invokeAll(tasks: MutableCollection<out Callable<T>>): MutableList<Future<T>> {
+        TODO("Not yet implemented")
+    }
+
+    override fun <T : Any?> invokeAll(
+        tasks: MutableCollection<out Callable<T>>,
+        timeout: Long,
+        unit: TimeUnit
+    ): MutableList<Future<T>> {
+        TODO("Not yet implemented")
+    }
+
+    override fun <T : Any?> invokeAny(tasks: MutableCollection<out Callable<T>>): T {
+        TODO("Not yet implemented")
+    }
+
+    override fun <T : Any?> invokeAny(tasks: MutableCollection<out Callable<T>>, timeout: Long, unit: TimeUnit): T {
+        TODO("Not yet implemented")
+    }
+
+    override fun <V : Any?> schedule(callable: Callable<V>, delay: Long, unit: TimeUnit): ScheduledFuture<V> {
+        TODO("Not yet implemented")
     }
 }
 

--- a/jicoco-test-kotlin/src/test/kotlin/org/jitsi/test/concurrent/FakeScheduledExecutorServiceTest.kt
+++ b/jicoco-test-kotlin/src/test/kotlin/org/jitsi/test/concurrent/FakeScheduledExecutorServiceTest.kt
@@ -19,7 +19,6 @@ package org.jitsi.test.concurrent
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
-import io.mockk.spyk
 import org.jitsi.utils.secs
 import java.util.concurrent.TimeUnit
 
@@ -27,7 +26,7 @@ class FakeScheduledExecutorServiceTest : ShouldSpec() {
     override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
 
     init {
-        val executor: FakeScheduledExecutorService = spyk()
+        val executor = FakeScheduledExecutorService()
 
         context("Scheduling a recurring job") {
             var numJobRuns = 0

--- a/jicoco/src/test/java/org/jitsi/retry/RetryStrategyTest.java
+++ b/jicoco/src/test/java/org/jitsi/retry/RetryStrategyTest.java
@@ -21,20 +21,14 @@ import org.jitsi.test.concurrent.*;
 import org.junit.jupiter.api.*;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 public class RetryStrategyTest
 {
     @Test
     public void testRetryCount()
     {
-        FakeScheduledExecutorService mockedExecutor = mock(
-            FakeScheduledExecutorService.class,
-            withSettings()
-                .useConstructor()
-                .defaultAnswer(CALLS_REAL_METHODS)
-        );
-        RetryStrategy retryStrategy = new RetryStrategy(mockedExecutor);
+        FakeScheduledExecutorService fakeExecutor = new FakeScheduledExecutorService();
+        RetryStrategy retryStrategy = new RetryStrategy(fakeExecutor);
 
         long initialDelay = 150L;
         long retryDelay = 50L;
@@ -45,40 +39,35 @@ public class RetryStrategyTest
                     initialDelay, retryDelay, false, targetRetryCount);
 
         retryStrategy.runRetryingTask(retryTask);
-        mockedExecutor.run();
+        fakeExecutor.run();
 
         // Check if the task has not been executed before initial delay
         assertEquals(0, retryTask.counter);
 
-        mockedExecutor.getClock().elapse(Duration.ofMillis(initialDelay + 10L));
-        mockedExecutor.run();
+        fakeExecutor.getClock().elapse(Duration.ofMillis(initialDelay + 10L));
+        fakeExecutor.run();
 
         // Should be 1 after 1st pass
         assertEquals(1, retryTask.counter);
 
         // Now sleep two time retry delay
-        mockedExecutor.getClock().elapse(Duration.ofMillis(retryDelay + 10L));
-        mockedExecutor.run();
-        mockedExecutor.getClock().elapse(Duration.ofMillis(retryDelay + 10L));
-        mockedExecutor.run();
+        fakeExecutor.getClock().elapse(Duration.ofMillis(retryDelay + 10L));
+        fakeExecutor.run();
+        fakeExecutor.getClock().elapse(Duration.ofMillis(retryDelay + 10L));
+        fakeExecutor.run();
         assertEquals(3, retryTask.counter);
 
         // Sleep a bit more to check if it has stopped
-        mockedExecutor.getClock().elapse(Duration.ofMillis(retryDelay + 10L));
-        mockedExecutor.run();
+        fakeExecutor.getClock().elapse(Duration.ofMillis(retryDelay + 10L));
+        fakeExecutor.run();
         assertEquals(3, retryTask.counter);
     }
 
     @Test
     public void testRetryWithException()
     {
-        FakeScheduledExecutorService mockedExecutor = mock(
-            FakeScheduledExecutorService.class,
-            withSettings()
-                .useConstructor()
-                .defaultAnswer(CALLS_REAL_METHODS)
-        );
-        RetryStrategy retryStrategy = new RetryStrategy(mockedExecutor);
+        FakeScheduledExecutorService fakeExecutor = new FakeScheduledExecutorService();
+        RetryStrategy retryStrategy = new RetryStrategy(fakeExecutor);
 
         long initialDelay = 30L;
         long retryDelay = 50L;
@@ -93,12 +82,12 @@ public class RetryStrategyTest
 
         retryStrategy.runRetryingTask(retryTask);
 
-        mockedExecutor.getClock().elapse(Duration.ofMillis(initialDelay + 10L));
-        mockedExecutor.run();
+        fakeExecutor.getClock().elapse(Duration.ofMillis(initialDelay + 10L));
+        fakeExecutor.run();
         for (int i = 0; i < 3; i++)
         {
-            mockedExecutor.getClock().elapse(Duration.ofMillis(retryDelay + 10L));
-            mockedExecutor.run();
+            fakeExecutor.getClock().elapse(Duration.ofMillis(retryDelay + 10L));
+            fakeExecutor.run();
         }
 
         assertEquals(1, retryTask.counter);
@@ -116,12 +105,12 @@ public class RetryStrategyTest
         retryStrategy.runRetryingTask(retryTask);
 
 
-        mockedExecutor.getClock().elapse(Duration.ofMillis(initialDelay + 10L));
-        mockedExecutor.run();
+        fakeExecutor.getClock().elapse(Duration.ofMillis(initialDelay + 10L));
+        fakeExecutor.run();
         for (int i = 0; i < 4; i++)
         {
-            mockedExecutor.getClock().elapse(Duration.ofMillis(retryDelay + 10L));
-            mockedExecutor.run();
+            fakeExecutor.getClock().elapse(Duration.ofMillis(retryDelay + 10L));
+            fakeExecutor.run();
         }
 
         assertEquals(3, retryTask.counter);
@@ -130,13 +119,8 @@ public class RetryStrategyTest
     @Test
     public void testCancel()
     {
-        FakeScheduledExecutorService mockedExecutor = mock(
-            FakeScheduledExecutorService.class,
-            withSettings()
-                .useConstructor()
-                .defaultAnswer(CALLS_REAL_METHODS)
-        );
-        RetryStrategy retryStrategy = new RetryStrategy(mockedExecutor);
+        FakeScheduledExecutorService fakeExecutor = new FakeScheduledExecutorService();
+        RetryStrategy retryStrategy = new RetryStrategy(fakeExecutor);
 
         long initialDelay = 30L;
         long retryDelay = 50L;
@@ -148,17 +132,17 @@ public class RetryStrategyTest
 
         retryStrategy.runRetryingTask(retryTask);
 
-        mockedExecutor.getClock().elapse(Duration.ofMillis(initialDelay + 10L));
-        mockedExecutor.run();
+        fakeExecutor.getClock().elapse(Duration.ofMillis(initialDelay + 10L));
+        fakeExecutor.run();
 
         retryStrategy.cancel();
 
         assertEquals(1, retryTask.counter);
 
-        mockedExecutor.getClock().elapse(Duration.ofMillis(retryDelay));
-        mockedExecutor.run();
-        mockedExecutor.getClock().elapse(Duration.ofMillis(retryDelay));
-        mockedExecutor.run();
+        fakeExecutor.getClock().elapse(Duration.ofMillis(retryDelay));
+        fakeExecutor.run();
+        fakeExecutor.getClock().elapse(Duration.ofMillis(retryDelay));
+        fakeExecutor.run();
 
         assertEquals(1, retryTask.counter);
     }


### PR DESCRIPTION
This lets us instantiate it without using mock/spy, which is substantially faster and uses less heap.