### PR TITLE
feat: Add resetAll() to MetricsContainer for testing.

### DIFF
--- a/jicoco-metrics/src/main/kotlin/org/jitsi/metrics/BooleanMetric.kt
+++ b/jicoco-metrics/src/main/kotlin/org/jitsi/metrics/BooleanMetric.kt
@@ -30,12 +30,14 @@ class BooleanMetric @JvmOverloads constructor(
     /** the namespace (prefix) of this metric */
     namespace: String,
     /** an optional initial value for this metric */
-    initialValue: Boolean = false
+    internal val initialValue: Boolean = false
 ) : Metric<Boolean>() {
     private val gauge =
         Gauge.build(name, help).namespace(namespace).create().apply { set(if (initialValue) 1.0 else 0.0) }
 
     override fun get() = gauge.get() != 0.0
+
+    override fun reset() = set(initialValue)
 
     override fun register(registry: CollectorRegistry) = this.also { registry.register(gauge) }
 

--- a/jicoco-metrics/src/main/kotlin/org/jitsi/metrics/CounterMetric.kt
+++ b/jicoco-metrics/src/main/kotlin/org/jitsi/metrics/CounterMetric.kt
@@ -34,12 +34,18 @@ class CounterMetric @JvmOverloads constructor(
     /** the namespace (prefix) of this metric */
     namespace: String,
     /** an optional initial value for this metric */
-    initialValue: Long = 0L
+    internal val initialValue: Long = 0L
 ) : Metric<Long>() {
     private val counter =
         Counter.build(name, help).namespace(namespace).create().apply { inc(initialValue.toDouble()) }
 
     override fun get() = counter.get().toLong()
+
+    override fun reset() {
+        synchronized(counter) {
+            counter.apply { clear() }.inc(initialValue.toDouble())
+        }
+    }
 
     override fun register(registry: CollectorRegistry) = this.also { registry.register(counter) }
 

--- a/jicoco-metrics/src/main/kotlin/org/jitsi/metrics/CounterMetric.kt
+++ b/jicoco-metrics/src/main/kotlin/org/jitsi/metrics/CounterMetric.kt
@@ -50,6 +50,11 @@ class CounterMetric @JvmOverloads constructor(
     override fun register(registry: CollectorRegistry) = this.also { registry.register(counter) }
 
     /**
+     * Atomically adds the given value to this counter.
+     */
+    fun add(delta: Long) = synchronized(counter) { counter.inc(delta.toDouble()) }
+
+    /**
      * Atomically adds the given value to this counter, returning the updated value.
      *
      * @return the updated value

--- a/jicoco-metrics/src/main/kotlin/org/jitsi/metrics/DoubleGaugeMetric.kt
+++ b/jicoco-metrics/src/main/kotlin/org/jitsi/metrics/DoubleGaugeMetric.kt
@@ -32,13 +32,20 @@ class DoubleGaugeMetric @JvmOverloads constructor(
     /** the namespace (prefix) of this metric */
     namespace: String,
     /** an optional initial value for this metric */
-    initialValue: Double = 0.0
+    internal val initialValue: Double = 0.0
 ) : Metric<Double>() {
     private val gauge = Gauge.build(name, help).namespace(namespace).create().apply { set(initialValue) }
 
     override fun get() = gauge.get()
 
+    override fun reset() = set(initialValue)
+
     override fun register(registry: CollectorRegistry) = this.also { registry.register(gauge) }
+
+    /**
+     * Sets the value of this gauge to the given value.
+     */
+    fun set(newValue: Double) = gauge.set(newValue)
 
     /**
      * Atomically sets the gauge to the given value, returning the updated value.

--- a/jicoco-metrics/src/main/kotlin/org/jitsi/metrics/InfoMetric.kt
+++ b/jicoco-metrics/src/main/kotlin/org/jitsi/metrics/InfoMetric.kt
@@ -32,11 +32,13 @@ class InfoMetric(
     /** the namespace (prefix) of this metric */
     namespace: String,
     /** the value of this info metric */
-    private val value: String
+    internal val value: String
 ) : Metric<String>() {
     private val info = Info.build(name, help).namespace(namespace).create().apply { info(name, value) }
 
     override fun get() = value
+
+    override fun reset() = info.info(name, value)
 
     override fun register(registry: CollectorRegistry) = this.also { registry.register(info) }
 }

--- a/jicoco-metrics/src/main/kotlin/org/jitsi/metrics/LongGaugeMetric.kt
+++ b/jicoco-metrics/src/main/kotlin/org/jitsi/metrics/LongGaugeMetric.kt
@@ -32,11 +32,13 @@ class LongGaugeMetric @JvmOverloads constructor(
     /** the namespace (prefix) of this metric */
     namespace: String,
     /** an optional initial value for this metric */
-    initialValue: Long = 0L
+    internal val initialValue: Long = 0L
 ) : Metric<Long>() {
     private val gauge = Gauge.build(name, help).namespace(namespace).create().apply { set(initialValue.toDouble()) }
 
     override fun get() = gauge.get().toLong()
+
+    override fun reset() = set(initialValue)
 
     override fun register(registry: CollectorRegistry) = this.also { registry.register(gauge) }
 

--- a/jicoco-metrics/src/main/kotlin/org/jitsi/metrics/Metric.kt
+++ b/jicoco-metrics/src/main/kotlin/org/jitsi/metrics/Metric.kt
@@ -36,6 +36,11 @@ sealed class Metric<T> {
     abstract fun get(): T
 
     /**
+     * Resets the value of this metric to its initial value.
+     */
+    internal abstract fun reset()
+
+    /**
      * Registers this metric with the given [CollectorRegistry] and returns it.
      */
     internal abstract fun register(registry: CollectorRegistry): Metric<T>

--- a/jicoco-metrics/src/main/kotlin/org/jitsi/metrics/MetricsContainer.kt
+++ b/jicoco-metrics/src/main/kotlin/org/jitsi/metrics/MetricsContainer.kt
@@ -163,4 +163,11 @@ open class MetricsContainer @JvmOverloads constructor(
         }
         return InfoMetric(name, help, namespace, value).apply { metrics[name] = register(registry) }
     }
+
+    /**
+     * Resets all metrics in this container to their default values.
+     */
+    fun resetAll() {
+        metrics.values.forEach { it.reset() }
+    }
 }

--- a/jicoco-metrics/src/test/kotlin/org/jitsi/metrics/MetricsContainerTest.kt
+++ b/jicoco-metrics/src/test/kotlin/org/jitsi/metrics/MetricsContainerTest.kt
@@ -66,7 +66,7 @@ class MetricsContainerTest : ShouldSpec() {
             }
             context("and altering their values") {
                 booleanMetric.set(!booleanMetric.get())
-                counter.addAndGet(5)
+                counter.add(5)
                 longGauge.set(5)
                 context("then resetting all metrics in the MetricsContainer") {
                     mc.resetAll()

--- a/jicoco-metrics/src/test/kotlin/org/jitsi/metrics/MetricsContainerTest.kt
+++ b/jicoco-metrics/src/test/kotlin/org/jitsi/metrics/MetricsContainerTest.kt
@@ -64,6 +64,19 @@ class MetricsContainerTest : ShouldSpec() {
                     a shouldContainExactly b
                 }
             }
+            context("and altering their values") {
+                booleanMetric.set(!booleanMetric.get())
+                counter.addAndGet(5)
+                longGauge.set(5)
+                context("then resetting all metrics in the MetricsContainer") {
+                    mc.resetAll()
+                    should("set all metric values to their initial values") {
+                        booleanMetric.get() shouldBe booleanMetric.initialValue
+                        counter.get() shouldBe counter.initialValue
+                        longGauge.get() shouldBe longGauge.initialValue
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Adds a `resetAll()` method to `MetricsContainer` which resets all of its `Metrics` to their respective initial values.