### PR TITLE
fix(reconnect): Handle - reconnect too quickly and fail.

### DIFF
--- a/jicoco/src/main/java/org/jitsi/xmpp/mucclient/MucClient.java
+++ b/jicoco/src/main/java/org/jitsi/xmpp/mucclient/MucClient.java
@@ -235,17 +235,10 @@ public class MucClient
             // too quickly and prosody is not fully up ('invalid-namespace' error)
             if (MucClient.this.connectRetry != null && xmppConnection.isConnected())
             {
-                try
-                {
-                    xmppConnection.disconnect();
-                }
-                catch(Exception ex)
-                {
-                    logger.error("Error disconnecting xmpp connection", ex);
-                }
+                xmppConnection.instantShutdown();
 
                 MucClient.this.connectRetry.runRetryingTask(
-                        new SimpleRetryTask(0, 1000, true, getConnectAndLoginCallable()));
+                        new SimpleRetryTask(0, 2000, true, getConnectAndLoginCallable()));
             }
         }
     };
@@ -693,10 +686,7 @@ public class MucClient
         {
             try
             {
-                if (!xmppConnection.isConnected())
-                {
-                    xmppConnection.connect();
-                }
+                xmppConnection.connect();
             }
             catch(Exception t)
             {

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <jersey.version>3.0.10</jersey.version>
         <jwt.version>0.12.6</jwt.version>
         <bouncycastle.version>1.78.1</bouncycastle.version>
-        <smack.version>4.4.6</smack.version>
+        <smack.version>4.4.8</smack.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
In case prosody is not fully up we can receive StreamErrorException: invalid-namespace and at the same time we are connected which will cause reconnection to stop.