### PR TITLE
Replace json-simple with Jackson

### DIFF
--- a/jicoco-mediajson/pom.xml
+++ b/jicoco-mediajson/pom.xml
@@ -44,19 +44,6 @@
       <version>${kotest.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.googlecode.json-simple</groupId>
-      <artifactId>json-simple</artifactId>
-      <version>${json.simple.version}</version>
-      <!-- json-simple 1.1.1 incorrectly listed junit as a compile dependency rather than a test dependency.
-    This has been fixed in its github repo but a new release hasn't been pushed to maven. -->
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/jicoco-mediajson/src/main/kotlin/org/jitsi/mediajson/MediaJson.kt
+++ b/jicoco-mediajson/src/main/kotlin/org/jitsi/mediajson/MediaJson.kt
@@ -17,6 +17,7 @@ package org.jitsi.mediajson
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter
 import com.fasterxml.jackson.annotation.JsonAnySetter
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.core.JsonGenerator
@@ -32,6 +33,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 
 private val objectMapper = jacksonObjectMapper().apply {
     configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL)
 }
 
 /**

--- a/jicoco-mediajson/src/test/kotlin/org/jitsi/mediajson/MediaJsonTest.kt
+++ b/jicoco-mediajson/src/test/kotlin/org/jitsi/mediajson/MediaJsonTest.kt
@@ -16,16 +16,17 @@
 package org.jitsi.mediajson
 
 import com.fasterxml.jackson.databind.exc.InvalidFormatException
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
-import org.json.simple.JSONObject
-import org.json.simple.parser.JSONParser
 
 class MediaJsonTest : ShouldSpec() {
-    val parser = JSONParser()
+    val mapper = jacksonObjectMapper()
 
     init {
         val seq = 123
@@ -38,22 +39,24 @@ class MediaJsonTest : ShouldSpec() {
             val event = StartEvent(seq, Start(tag, MediaFormat(enc, sampleRate, channels, params)))
 
             context("Serializing") {
-                val parsed = parser.parse(event.toJson())
+                val parsed = mapper.readTree(event.toJson())
 
-                parsed.shouldBeInstanceOf<JSONObject>()
-                parsed["event"] shouldBe "start"
+                parsed.shouldBeInstanceOf<ObjectNode>()
+                parsed.get("event").asText() shouldBe "start"
                 // intentionally encoded as a string
-                parsed["sequenceNumber"] shouldBe seq.toString()
-                val start = parsed["start"]
-                start.shouldBeInstanceOf<JSONObject>()
-                start["tag"] shouldBe tag
-                start["customParameters"] shouldBe null
-                val mediaFormat = start["mediaFormat"]
-                mediaFormat.shouldBeInstanceOf<JSONObject>()
-                mediaFormat["encoding"] shouldBe enc
-                mediaFormat["sampleRate"] shouldBe sampleRate
-                mediaFormat["channels"] shouldBe channels
-                mediaFormat["parameters"] shouldBe params
+                parsed.get("sequenceNumber").asText() shouldBe seq.toString()
+                val start = parsed.get("start")
+                start.shouldBeInstanceOf<ObjectNode>()
+                start.get("tag").asText() shouldBe tag
+                start.get("customParameters") shouldBe null
+                val mediaFormat = start.get("mediaFormat")
+                mediaFormat.shouldBeInstanceOf<ObjectNode>()
+                mediaFormat.get("encoding").asText() shouldBe enc
+                mediaFormat.get("sampleRate").asInt() shouldBe sampleRate
+                mediaFormat.get("channels").asInt() shouldBe channels
+                val parsedParams = mediaFormat.get("parameters")
+                parsedParams.shouldBeInstanceOf<ObjectNode>()
+                params.forEach { (k, v) -> parsedParams.get(k).asText() shouldBe v }
             }
             context("Parsing") {
                 val parsed = Event.parse(event.toJson())
@@ -74,19 +77,19 @@ class MediaJsonTest : ShouldSpec() {
             val event = MediaEvent(seq, Media(tag, chunk, timestamp, payload))
 
             context("Serializing") {
-                val parsed = parser.parse(event.toJson())
-                parsed.shouldBeInstanceOf<JSONObject>()
-                parsed["event"] shouldBe "media"
+                val parsed = mapper.readTree(event.toJson())
+                parsed.shouldBeInstanceOf<ObjectNode>()
+                parsed.get("event").asText() shouldBe "media"
                 // intentionally encoded as a string
-                parsed["sequenceNumber"] shouldBe seq.toString()
-                val media = parsed["media"]
-                media.shouldBeInstanceOf<JSONObject>()
-                media["tag"] shouldBe tag
+                parsed.get("sequenceNumber").asText() shouldBe seq.toString()
+                val media = parsed.get("media")
+                media.shouldBeInstanceOf<ObjectNode>()
+                media.get("tag").asText() shouldBe tag
                 // intentionally encoded as a string
-                media["chunk"] shouldBe chunk.toString()
+                media.get("chunk").asText() shouldBe chunk.toString()
                 // intentionally encoded as a string
-                media["timestamp"] shouldBe timestamp.toString()
-                media["payload"] shouldBe payload
+                media.get("timestamp").asText() shouldBe timestamp.toString()
+                media.get("payload").asText() shouldBe payload
             }
             context("Parsing") {
                 val parsed = Event.parse(event.toJson())
@@ -99,10 +102,10 @@ class MediaJsonTest : ShouldSpec() {
             val event = PingEvent(id)
 
             context("Serializing") {
-                val parsed = parser.parse(event.toJson())
-                parsed.shouldBeInstanceOf<JSONObject>()
-                parsed["event"] shouldBe "ping"
-                parsed["id"] shouldBe id
+                val parsed = mapper.readTree(event.toJson())
+                parsed.shouldBeInstanceOf<ObjectNode>()
+                parsed.get("event").asText() shouldBe "ping"
+                parsed.get("id").asInt() shouldBe id
             }
             context("Parsing") {
                 val parsed = Event.parse(event.toJson())
@@ -115,10 +118,10 @@ class MediaJsonTest : ShouldSpec() {
             val event = PongEvent(id)
 
             context("Serializing") {
-                val parsed = parser.parse(event.toJson())
-                parsed.shouldBeInstanceOf<JSONObject>()
-                parsed["event"] shouldBe "pong"
-                parsed["id"] shouldBe id
+                val parsed = mapper.readTree(event.toJson())
+                parsed.shouldBeInstanceOf<ObjectNode>()
+                parsed.get("event").asText() shouldBe "pong"
+                parsed.get("id").asInt() shouldBe id
             }
             context("Parsing") {
                 val parsed = Event.parse(event.toJson())
@@ -130,9 +133,9 @@ class MediaJsonTest : ShouldSpec() {
             val event = TranscriptionResultEvent()
 
             context("Serializing") {
-                val parsed = parser.parse(event.toJson())
-                parsed.shouldBeInstanceOf<JSONObject>()
-                parsed["event"] shouldBe "transcription-result"
+                val parsed = mapper.readTree(event.toJson())
+                parsed.shouldBeInstanceOf<ObjectNode>()
+                parsed.get("event").asText() shouldBe "transcription-result"
             }
             context("Parsing") {
                 val parsed = Event.parse(event.toJson())
@@ -144,15 +147,15 @@ class MediaJsonTest : ShouldSpec() {
             context("Start") {
                 val parsed = Event.parse(
                     """
-                    { 
+                    {
                         "event": "start",
                         "sequenceNumber": "0",
                         "start": {
                             "tag": "incoming",
-                            "mediaFormat": { 
-                                "encoding": "audio/x-mulaw", 
-                                "sampleRate": 8000, 
-                                "channels": 1 
+                            "mediaFormat": {
+                                "encoding": "audio/x-mulaw",
+                                "sampleRate": 8000,
+                                "channels": 1
                             },
                             "customParameters": {
                                 "text1":"12312",
@@ -176,15 +179,15 @@ class MediaJsonTest : ShouldSpec() {
             context("Start with sequence number as int") {
                 val parsed = Event.parse(
                     """
-                    { 
+                    {
                         "event": "start",
                         "sequenceNumber": 0,
                         "start": {
                             "tag": "incoming",
-                            "mediaFormat": { 
-                                "encoding": "audio/x-mulaw", 
-                                "sampleRate": 8000, 
-                                "channels": 1 
+                            "mediaFormat": {
+                                "encoding": "audio/x-mulaw",
+                                "sampleRate": 8000,
+                                "channels": 1
                             },
                             "customParameters": {
                                 "text1":"12312",
@@ -203,15 +206,15 @@ class MediaJsonTest : ShouldSpec() {
             context("Media") {
                 val parsed = Event.parse(
                     """
-                    { 
+                    {
                         "event": "media",
-                        "sequenceNumber": "2", 
-                        "media": { 
-                            "tag": "incoming", 
-                            "chunk": "1",    
+                        "sequenceNumber": "2",
+                        "media": {
+                            "tag": "incoming",
+                            "chunk": "1",
                             "timestamp": "5",
                             "payload": "no+JhoaJjpzSHxAKBgYJ...=="
-                        } 
+                        }
                     }
                     """.trimIndent()
                 )
@@ -301,27 +304,27 @@ class MediaJsonTest : ShouldSpec() {
                 parsed.shouldBeInstanceOf<TranscriptionResultEvent>()
 
                 val serialized = parsed.toJson()
-                val reparsed = parser.parse(serialized)
-                reparsed.shouldBeInstanceOf<JSONObject>()
+                val reparsed = mapper.readTree(serialized)
+                reparsed.shouldBeInstanceOf<ObjectNode>()
 
-                reparsed["event"] shouldBe "transcription-result"
-                reparsed["type"] shouldBe "transcription-result"
-                reparsed["message_id"] shouldBe "item_CnopdEudFcwXCkZfCIHrC"
-                reparsed["is_interim"] shouldBe false
-                reparsed["timestamp"] shouldBe 1765989508172L
+                reparsed.get("event").asText() shouldBe "transcription-result"
+                reparsed.get("type").asText() shouldBe "transcription-result"
+                reparsed.get("message_id").asText() shouldBe "item_CnopdEudFcwXCkZfCIHrC"
+                reparsed.get("is_interim").asBoolean() shouldBe false
+                reparsed.get("timestamp").asLong() shouldBe 1765989508172L
 
-                val transcript = reparsed["transcript"]
-                transcript.shouldBeInstanceOf<List<*>>()
-                transcript.size shouldBe 1
-                val transcriptItem = transcript[0] as Map<*, *>
-                transcriptItem.shouldBeInstanceOf<Map<*, *>>()
-                transcriptItem["confidence"] shouldBe 0.999666973709317
-                transcriptItem["text"] shouldBe "blah blah blah"
+                val transcript = reparsed.get("transcript")
+                transcript.shouldBeInstanceOf<ArrayNode>()
+                transcript.size() shouldBe 1
+                val transcriptItem = transcript[0]
+                transcriptItem.shouldBeInstanceOf<ObjectNode>()
+                transcriptItem.get("confidence").asDouble() shouldBe 0.999666973709317
+                transcriptItem.get("text").asText() shouldBe "blah blah blah"
 
-                val participant = reparsed["participant"]
-                participant.shouldBeInstanceOf<Map<*, *>>()
-                participant["id"] shouldBe "08847b00"
-                participant["ssrc"] shouldBe "1776301157"
+                val participant = reparsed.get("participant")
+                participant.shouldBeInstanceOf<ObjectNode>()
+                participant.get("id").asText() shouldBe "08847b00"
+                participant.get("ssrc").asText() shouldBe "1776301157"
             }
         }
         context("Parsing invalid samples") {
@@ -329,15 +332,15 @@ class MediaJsonTest : ShouldSpec() {
                 shouldThrow<InvalidFormatException> {
                     Event.parse(
                         """
-                        { 
+                        {
                             "event": "media",
-                            "sequenceNumber": "not a number", 
-                            "media": { 
-                                "tag": "incoming", 
-                                "chunk": "1",    
+                            "sequenceNumber": "not a number",
+                            "media": {
+                                "tag": "incoming",
+                                "chunk": "1",
                                 "timestamp": "5",
                                 "payload": "no+JhoaJjpzSHxAKBgYJ...=="
-                            } 
+                            }
                         }
                         """.trimIndent()
                     )
@@ -347,15 +350,15 @@ class MediaJsonTest : ShouldSpec() {
                 shouldThrow<InvalidFormatException> {
                     Event.parse(
                         """
-                        { 
+                        {
                             "event": "media",
-                            "sequenceNumber": "1", 
-                            "media": { 
-                                "tag": "incoming", 
-                                "chunk": "not a number",    
+                            "sequenceNumber": "1",
+                            "media": {
+                                "tag": "incoming",
+                                "chunk": "not a number",
                                 "timestamp": "5",
                                 "payload": "no+JhoaJjpzSHxAKBgYJ...=="
-                            } 
+                            }
                         }
                         """.trimIndent()
                     )
@@ -365,15 +368,15 @@ class MediaJsonTest : ShouldSpec() {
                 shouldThrow<InvalidFormatException> {
                     Event.parse(
                         """
-                        { 
+                        {
                             "event": "media",
-                            "sequenceNumber": "1", 
-                            "media": { 
-                                "tag": "incoming", 
-                                "chunk": "1",    
+                            "sequenceNumber": "1",
+                            "media": {
+                                "tag": "incoming",
+                                "chunk": "1",
                                 "timestamp": "not a number",
                                 "payload": "no+JhoaJjpzSHxAKBgYJ...=="
-                            } 
+                            }
                         }
                         """.trimIndent()
                     )

--- a/jicoco-metrics/pom.xml
+++ b/jicoco-metrics/pom.xml
@@ -41,6 +41,11 @@
             <artifactId>jitsi-utils</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient</artifactId>
             <version>${prometheus.version}</version>

--- a/jicoco-metrics/src/main/kotlin/org/jitsi/metrics/HistogramMetric.kt
+++ b/jicoco-metrics/src/main/kotlin/org/jitsi/metrics/HistogramMetric.kt
@@ -15,9 +15,12 @@
  */
 package org.jitsi.metrics
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
 import io.prometheus.client.CollectorRegistry
 import io.prometheus.client.Histogram
-import org.json.simple.JSONObject
+
+private val mapper = ObjectMapper()
 
 class HistogramMetric(
     override val name: String,
@@ -26,10 +29,10 @@ class HistogramMetric(
     /** the namespace (prefix) of this metric */
     val namespace: String,
     vararg buckets: Double
-) : Metric<JSONObject>() {
+) : Metric<ObjectNode>() {
     val histogram: Histogram = Histogram.build(name, help).namespace(namespace).buckets(*buckets).create()
 
-    override fun get(): JSONObject = JSONObject().apply {
+    override fun get(): ObjectNode = mapper.createObjectNode().apply {
         histogram.collect().forEach {
             it.samples.forEach { sample ->
                 if (sample.name.startsWith("${namespace}_${name}_")) {
@@ -46,5 +49,5 @@ class HistogramMetric(
 
     override fun reset() = histogram.clear()
 
-    override fun register(registry: CollectorRegistry): Metric<JSONObject> = this.also { registry.register(histogram) }
+    override fun register(registry: CollectorRegistry): Metric<ObjectNode> = this.also { registry.register(histogram) }
 }

--- a/jicoco-metrics/src/main/kotlin/org/jitsi/metrics/HistogramMetric.kt
+++ b/jicoco-metrics/src/main/kotlin/org/jitsi/metrics/HistogramMetric.kt
@@ -15,12 +15,10 @@
  */
 package org.jitsi.metrics
 
-import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import io.prometheus.client.CollectorRegistry
 import io.prometheus.client.Histogram
-
-private val mapper = ObjectMapper()
 
 class HistogramMetric(
     override val name: String,
@@ -32,7 +30,7 @@ class HistogramMetric(
 ) : Metric<ObjectNode>() {
     val histogram: Histogram = Histogram.build(name, help).namespace(namespace).buckets(*buckets).create()
 
-    override fun get(): ObjectNode = mapper.createObjectNode().apply {
+    override fun get(): ObjectNode = JsonNodeFactory.instance.objectNode().apply {
         histogram.collect().forEach {
             it.samples.forEach { sample ->
                 if (sample.name.startsWith("${namespace}_${name}_")) {

--- a/jicoco-metrics/src/main/kotlin/org/jitsi/metrics/MetricsContainer.kt
+++ b/jicoco-metrics/src/main/kotlin/org/jitsi/metrics/MetricsContainer.kt
@@ -15,10 +15,10 @@
  */
 package org.jitsi.metrics
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.prometheus.client.CollectorRegistry
 import io.prometheus.client.exporter.common.TextFormat
 import org.jitsi.utils.logging2.createLogger
-import org.json.simple.JSONObject
 import java.io.IOException
 import java.io.StringWriter
 
@@ -32,6 +32,7 @@ open class MetricsContainer @JvmOverloads constructor(
     val namespace: String = "jitsi"
 ) {
     private val logger = createLogger()
+    private val jsonMapper = ObjectMapper()
 
     /**
      * Defines the behavior when registering a metric with a name in use by an existing metric.
@@ -53,7 +54,9 @@ open class MetricsContainer @JvmOverloads constructor(
      * @return a JSON string of the metrics in this instance
      */
     open val jsonString: String
-        get() = JSONObject(metrics.filter { it.value.supportsJson }.mapValues { it.value.get() }).toJSONString()
+        get() = jsonMapper.valueToTree<com.fasterxml.jackson.databind.node.ObjectNode>(
+            metrics.filter { it.value.supportsJson }.mapValues { it.value.get() }
+        ).toString()
 
     /**
      * Returns the metrics in this instance in the Prometheus text-based format.

--- a/jicoco-metrics/src/main/kotlin/org/jitsi/metrics/MetricsContainer.kt
+++ b/jicoco-metrics/src/main/kotlin/org/jitsi/metrics/MetricsContainer.kt
@@ -16,6 +16,7 @@
 package org.jitsi.metrics
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
 import io.prometheus.client.CollectorRegistry
 import io.prometheus.client.exporter.common.TextFormat
 import org.jitsi.utils.logging2.createLogger
@@ -54,7 +55,7 @@ open class MetricsContainer @JvmOverloads constructor(
      * @return a JSON string of the metrics in this instance
      */
     open val jsonString: String
-        get() = jsonMapper.valueToTree<com.fasterxml.jackson.databind.node.ObjectNode>(
+        get() = jsonMapper.valueToTree<ObjectNode>(
             metrics.filter { it.value.supportsJson }.mapValues { it.value.get() }
         ).toString()
 

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>jitsi-utils</artifactId>
-                <version>1.0-119-ga7b23ff</version>
+                <version>1.0-150-g4ab9a3b</version>
             </dependency>
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.0</junit.version>
-        <json.simple.version>1.1.1</json.simple.version>
         <kotlin.version>1.9.10</kotlin.version>
         <jackson.version>2.17.1</jackson.version>
         <kotest.version>5.7.2</kotest.version>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.0</junit.version>
         <kotlin.version>1.9.10</kotlin.version>
-        <jackson.version>2.17.1</jackson.version>
+        <jackson.version>2.19.0</jackson.version>
         <kotest.version>5.7.2</kotest.version>
         <mockk.version>1.13.8</mockk.version>
         <prometheus.version>0.16.0</prometheus.version>


### PR DESCRIPTION
Replace the `org.json.simple` dependency with Jackson (`jackson-databind`).

- Migrate `MetricsContainer` and `HistogramMetric` to use `ObjectNode`/`ArrayNode`
- Migrate `mediajson` serialization; add `NON_NULL` property inclusion to match previous null-omission behavior
- Update `jitsi-utils` to `1.0-SNAPSHOT`