### PR TITLE
Add a SourcesEvent to MediaJson

### DIFF
--- a/jicoco-mediajson/src/main/kotlin/org/jitsi/mediajson/MediaJson.kt
+++ b/jicoco-mediajson/src/main/kotlin/org/jitsi/mediajson/MediaJson.kt
@@ -93,6 +93,16 @@ class TranscriptionResultEvent : Event("transcription-result") {
 
 class SessionEndEvent : Event("session-end")
 
+/**
+ * Declares the set of source names the bridge will export (send out) to the peer, and the set it requests (wants to
+ * receive) from the peer. Only ever sent by the bridge -- like [SessionEndEvent] it is not registered in [Event]'s
+ * subtypes for parsing.
+ */
+data class SourcesEvent(
+    val exports: List<String>,
+    val requests: List<String>
+) : Event("sources")
+
 data class MediaFormat(
     val encoding: String,
     val sampleRate: Int,

--- a/jicoco-mediajson/src/test/kotlin/org/jitsi/mediajson/MediaJsonTest.kt
+++ b/jicoco-mediajson/src/test/kotlin/org/jitsi/mediajson/MediaJsonTest.kt
@@ -143,6 +143,32 @@ class MediaJsonTest : ShouldSpec() {
                 parsed.event shouldBe "transcription-result"
             }
         }
+        context("SourcesEvent") {
+            val event = SourcesEvent(
+                exports = listOf("523834112-a0", "2394a3432-a0"),
+                requests = listOf("523834112-a0.en", "2394a3432-a0.hi")
+            )
+
+            context("Serializing") {
+                val parsed = mapper.readTree(event.toJson())
+                parsed.shouldBeInstanceOf<ObjectNode>()
+                parsed.get("event").asText() shouldBe "sources"
+                val exports = parsed.get("exports")
+                exports.shouldBeInstanceOf<ArrayNode>()
+                exports.map { it.asText() } shouldBe listOf("523834112-a0", "2394a3432-a0")
+                val requests = parsed.get("requests")
+                requests.shouldBeInstanceOf<ArrayNode>()
+                requests.map { it.asText() } shouldBe listOf("523834112-a0.en", "2394a3432-a0.hi")
+            }
+
+            context("With empty lists") {
+                val parsed = mapper.readTree(SourcesEvent(emptyList(), emptyList()).toJson())
+                parsed.shouldBeInstanceOf<ObjectNode>()
+                parsed.get("event").asText() shouldBe "sources"
+                parsed.get("exports").shouldBeInstanceOf<ArrayNode>().size() shouldBe 0
+                parsed.get("requests").shouldBeInstanceOf<ArrayNode>().size() shouldBe 0
+            }
+        }
         context("Parsing valid samples") {
             context("Start") {
                 val parsed = Event.parse(


### PR DESCRIPTION
Add a bridge-sent `sources` event to the MediaJson protocol, carrying the source names the bridge will **export** (send out) to the peer and the source names it **requests** (wants to receive) from the peer:

```json
{"event":"sources","exports":["523834112-a0","2394a3432-a0"],"requests":["523834112-a0.en","2394a3432-a0.hi"]}
```

This will be used by the videobridge exporter to tell a translator/transcriber connection which sources it is sending and which (e.g. translated) sources it wants back, corresponding to the new `exports`/`requests` child elements on the colibri2 `<connect>` element.

Like `SessionEndEvent`, this event is only ever sent by the bridge, so it is not registered in `Event`'s `@JsonSubTypes` parse path.

Includes `MediaJsonTest` coverage for serialization (populated and empty lists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
