### PR TITLE
feat: add diarize field to mediajson Start event

### DIFF
--- a/jicoco-mediajson/src/main/kotlin/org/jitsi/mediajson/MediaJson.kt
+++ b/jicoco-mediajson/src/main/kotlin/org/jitsi/mediajson/MediaJson.kt
@@ -139,7 +139,8 @@ data class MediaFormat(
 data class Start(
     val tag: String,
     val mediaFormat: MediaFormat,
-    val customParameters: CustomParameters? = null
+    val customParameters: CustomParameters? = null,
+    val diarize: Boolean? = null
 )
 
 data class CustomParameters(

--- a/jicoco-mediajson/src/test/kotlin/org/jitsi/mediajson/MediaJsonTest.kt
+++ b/jicoco-mediajson/src/test/kotlin/org/jitsi/mediajson/MediaJsonTest.kt
@@ -49,6 +49,8 @@ class MediaJsonTest : ShouldSpec() {
                 start.shouldBeInstanceOf<ObjectNode>()
                 start.get("tag").asText() shouldBe tag
                 start.get("customParameters") shouldBe null
+                // diarize is null and must be omitted from the JSON.
+                start.get("diarize") shouldBe null
                 val mediaFormat = start.get("mediaFormat")
                 mediaFormat.shouldBeInstanceOf<ObjectNode>()
                 mediaFormat.get("encoding").asText() shouldBe enc
@@ -68,6 +70,17 @@ class MediaJsonTest : ShouldSpec() {
                 parsedList.size shouldBe 2
                 parsedList[0] shouldBe event
                 parsedList[1] shouldBe event
+            }
+            context("With diarize set") {
+                val diarizeEvent = StartEvent(
+                    seq,
+                    Start(tag, MediaFormat(enc, sampleRate, channels, params), diarize = true)
+                )
+                val parsed = mapper.readTree(diarizeEvent.toJson())
+                parsed.shouldBeInstanceOf<ObjectNode>()
+                val start = parsed.get("start")
+                start.shouldBeInstanceOf<ObjectNode>()
+                start.get("diarize").asBoolean() shouldBe true
             }
         }
         context("MediaEvent") {
@@ -223,6 +236,30 @@ class MediaJsonTest : ShouldSpec() {
                 parsed.start.mediaFormat.channels shouldBe 1
                 parsed.start.customParameters.shouldNotBeNull()
                 parsed.start.customParameters?.endpointId shouldBe "abcdabcd"
+                // diarize is absent from the JSON and must parse as null.
+                parsed.start.diarize shouldBe null
+            }
+            context("Start with diarize") {
+                val parsed = Event.parse(
+                    """
+                    {
+                        "event": "start",
+                        "sequenceNumber": "0",
+                        "start": {
+                            "tag": "incoming",
+                            "mediaFormat": {
+                                "encoding": "audio/x-mulaw",
+                                "sampleRate": 8000,
+                                "channels": 1
+                            },
+                            "diarize": true
+                        }
+                    }
+                    """.trimIndent()
+                )
+
+                parsed.shouldBeInstanceOf<StartEvent>()
+                parsed.start.diarize shouldBe true
             }
             context("Start with sequence number as int") {
                 val parsed = Event.parse(


### PR DESCRIPTION
Adds an optional `diarize: Boolean?` field to the media-json `Start` event so the videobridge can enable speaker diarization per endpoint on the transcriber `start` event. Defaults to null and is omitted from the wire (NON_NULL inclusion) when unset, so the format is unchanged for existing callers. The opus-transcriber-proxy already reads `start.diarize` (an explicit boolean overrides its global config).

Part of a multi-repo change enabling per-endpoint speaker diarization. The four Maven repos share the branch `diarization-endpoint-control` so CI builds them together; no dependency version bumps are included.

---

**Related PRs** (per-endpoint speaker diarization, multi-repo):
- jitsi-meet: jitsi/jitsi-meet#17614
- jitsi-xmpp-extensions: jitsi/jitsi-xmpp-extensions#145
- jicoco: jitsi/jicoco#238
- jicofo: jitsi/jicofo#1291
- jitsi-videobridge: jitsi/jitsi-videobridge#2431
- opus-transcriber-proxy: jitsi/opus-transcriber-proxy#106
